### PR TITLE
update classificatie prefix after model change

### DIFF
--- a/dispatch-rules/advies-budgetwijziging.js
+++ b/dispatch-rules/advies-budgetwijziging.js
@@ -41,7 +41,7 @@ let rule = {
         }
 
         ?aboutEenheid a ?worshipType;
-          <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+          <http://www.w3.org/ns/org#classification> ?worshipClassifications.
 
        {
          ?aboutEenheid mu:uuid ?uuid;

--- a/dispatch-rules/advies-meerjarenplanwijziging.js
+++ b/dispatch-rules/advies-meerjarenplanwijziging.js
@@ -40,7 +40,7 @@ let rule = {
          }
 
          ?aboutEenheid a ?worshipType;
-           <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+           <http://www.w3.org/ns/org#classification> ?worshipClassifications.
 
           VALUES ?classificatie {
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
@@ -51,7 +51,7 @@ let rule = {
             a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>.
 
           ?bestuurseenheid <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur;
-            <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
+            <http://www.w3.org/ns/org#classification> ?classificatie;
             mu:uuid ?uuid;
             <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
 

--- a/dispatch-rules/besluit-budgetwijziging.js
+++ b/dispatch-rules/besluit-budgetwijziging.js
@@ -56,7 +56,7 @@ let rule = {
         }
 
         ?aboutEenheid a ?worshipType;
-          <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+          <http://www.w3.org/ns/org#classification> ?worshipClassifications.
 
        {
          ?aboutEenheid mu:uuid ?uuid;

--- a/dispatch-rules/besluit-meerjarenplanwijziging.js
+++ b/dispatch-rules/besluit-meerjarenplanwijziging.js
@@ -56,7 +56,7 @@ let rule = {
         }
 
         ?aboutEenheid a ?worshipType;
-          <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+          <http://www.w3.org/ns/org#classification> ?worshipClassifications.
 
        {
          ?aboutEenheid mu:uuid ?uuid;

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -22,14 +22,14 @@ let rule = {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
             ?bestuurseenheid org:hasSubOrganization ?sender;
-            <http://data.vlaanderen.be/ns/besluit#classificatie>
+            <http://www.w3.org/ns/org#classification>
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
               skos:prefLabel ?label;
               mu:uuid ?uuid.
 
             FILTER EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             }
           } UNION {
@@ -42,7 +42,7 @@ let rule = {
 
             FILTER EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             }
           }
@@ -73,7 +73,7 @@ rule = {
             ${toezichthoudendeQuerySnippet()}
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           } UNION {
@@ -84,7 +84,7 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           } UNION {
@@ -97,7 +97,7 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           }

--- a/dispatch-rules/jaarrekening.js
+++ b/dispatch-rules/jaarrekening.js
@@ -22,7 +22,7 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         {
           ?bestuurseenheid org:hasSubOrganization ?sender;
-            <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+            <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
             mu:uuid ?uuid;
             skos:prefLabel ?label.
         } UNION {
@@ -33,7 +33,7 @@ let rule = {
             skos:prefLabel ?label.
 
           ?centraalBestuur org:hasSubOrganization ?bestuurseenheid;
-            <http://data.vlaanderen.be/ns/besluit#classificatie>
+            <http://www.w3.org/ns/org#classification>
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
         }
       }
@@ -64,7 +64,7 @@ rule = {
           ${toezichthoudendeQuerySnippet()}
           FILTER NOT EXISTS {
             ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-              <http://data.vlaanderen.be/ns/besluit#classificatie>
+              <http://www.w3.org/ns/org#classification>
                 <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
           }
         } UNION {
@@ -76,7 +76,7 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
         } UNION {
@@ -87,7 +87,7 @@ rule = {
              skos:prefLabel ?label.
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?bestuurseenheid;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
         }

--- a/dispatch-rules/meerjarenplanwijziging.js
+++ b/dispatch-rules/meerjarenplanwijziging.js
@@ -23,14 +23,14 @@ let rule = {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
             ?bestuurseenheid org:hasSubOrganization ?sender;
-            <http://data.vlaanderen.be/ns/besluit#classificatie>
+            <http://www.w3.org/ns/org#classification>
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
               skos:prefLabel ?label;
               mu:uuid ?uuid.
 
             FILTER EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             }
           } UNION {
@@ -43,7 +43,7 @@ let rule = {
 
             FILTER EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             }
           }
@@ -76,7 +76,7 @@ rule = {
             ${toezichthoudendeQuerySnippet()}
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           } UNION {
@@ -87,7 +87,7 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           } UNION {
@@ -101,7 +101,7 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
+                <http://www.w3.org/ns/org#classification>
                   <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           }

--- a/dispatch-rules/query-snippets.js
+++ b/dispatch-rules/query-snippets.js
@@ -8,7 +8,7 @@ export const toezichthoudendeQuerySnippet = () => `
             a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>.
 
           ?bestuurseenheid <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur;
-            <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
+            <http://www.w3.org/ns/org#classification> ?classificatie;
             mu:uuid ?uuid;
             <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
 `;

--- a/dispatch-rules/schorsingsbesluit.js
+++ b/dispatch-rules/schorsingsbesluit.js
@@ -56,7 +56,7 @@ let rule = {
         }
 
         ?aboutEenheid a ?worshipType;
-          <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+          <http://www.w3.org/ns/org#classification> ?worshipClassifications.
 
        {
          ?aboutEenheid mu:uuid ?uuid;


### PR DESCRIPTION
This replaces the prefix besluit:classificatie to org:classification after data model change.

Parent PR: https://github.com/lblod/app-worship-decisions-database/pull/33