### PR TITLE
[ RepresentatiefOrgaan ] Adding missing dispatch rules for decisions 

### DIFF
--- a/dispatch-rules/entrypoint.js
+++ b/dispatch-rules/entrypoint.js
@@ -12,6 +12,13 @@ import adviesMeerjarenplanwijzigingRules from './advies-meerjarenplanwijziging';
 
 import besluitMeerjarenplanwijzigingRules from './besluit-meerjarenplanwijziging';
 
+import erekenningReguliereProcedure from './erekenning-reguliere-procedure';
+import naamswijziging from './naamswijziging';
+import opheffingVanAnnexeKerkenEnKapelanijen from './opheffing-van-annexe-kerken-en-kapelanijen';
+import wijzigingGebiedsomschrijving from './wijziging-gebiedsomschrijving';
+import samenvoeging from './samenvoeging';
+
+
 /*
  * This file exports a list of rule objects, which helps deduce who the targets are for a
  * a specific submission.
@@ -41,7 +48,12 @@ const rules = [
   ...besluitBudgetwijzigingRules,
   ...meerjarenplanwijzigingRules,
   ...adviesMeerjarenplanwijzigingRules,
-  ...besluitMeerjarenplanwijzigingRules
+  ...besluitMeerjarenplanwijzigingRules,
+  ...erekenningReguliereProcedure,
+  ...naamswijziging,
+  ...opheffingVanAnnexeKerkenEnKapelanijen,
+  ...samenvoeging,
+  ...wijzigingGebiedsomschrijving
 ];
 
 export default rules;

--- a/dispatch-rules/erekenning-reguliere-procedure.js
+++ b/dispatch-rules/erekenning-reguliere-procedure.js
@@ -1,0 +1,51 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+/* Excel: Rules number: 142
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+**/
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73', // Erkenning - reguliere procedure
+  matchSentByEenheidClass: eenheidClass =>
+    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO
+  destinationInfoQuery: ( sender, submission ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
+        ?submission a meb:Submission;
+          pav:createdBy ?sender;
+          prov:generated ?formData.
+
+        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
+
+         VALUES ?bestuurseenheid {
+           ${sparqlEscapeUri(sender)}
+         }
+
+        BIND(<http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> as ?worshipType)
+        BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> as ?worshipClassification)
+
+        ?bestuurseenheid a ?worshipType ;
+          mu:uuid ?uuid;
+          besluit:classificatie ?worshipClassification;
+          skos:prefLabel ?label.
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/naamswijziging.js
+++ b/dispatch-rules/naamswijziging.js
@@ -1,0 +1,51 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+/* Excel: Rules number: 144
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+**/
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777', // Naamswijziging
+  matchSentByEenheidClass: eenheidClass =>
+    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO
+  destinationInfoQuery: ( sender, submission ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
+        ?submission a meb:Submission;
+          pav:createdBy ?sender;
+          prov:generated ?formData.
+
+        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
+
+         VALUES ?bestuurseenheid {
+           ${sparqlEscapeUri(sender)}
+         }
+
+        BIND(<http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> as ?worshipType)
+        BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> as ?worshipClassification)
+
+        ?bestuurseenheid a ?worshipType ;
+          mu:uuid ?uuid;
+          besluit:classificatie ?worshipClassification;
+          skos:prefLabel ?label.
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
+++ b/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
@@ -1,0 +1,51 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+/* Excel: Rules number: 140
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+**/
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e', // Opheffing van annexe kerken en kapelanijen
+  matchSentByEenheidClass: eenheidClass =>
+    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO
+  destinationInfoQuery: ( sender, submission ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
+        ?submission a meb:Submission;
+          pav:createdBy ?sender;
+          prov:generated ?formData.
+
+        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
+
+         VALUES ?bestuurseenheid {
+           ${sparqlEscapeUri(sender)}
+         }
+
+        BIND(<http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> as ?worshipType)
+        BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> as ?worshipClassification)
+
+        ?bestuurseenheid a ?worshipType ;
+          mu:uuid ?uuid;
+          besluit:classificatie ?worshipClassification;
+          skos:prefLabel ?label.
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/samenvoeging.js
+++ b/dispatch-rules/samenvoeging.js
@@ -1,0 +1,51 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+/* Excel: Rules number: 141
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+**/
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a', // Samenvoeging
+  matchSentByEenheidClass: eenheidClass =>
+    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO
+  destinationInfoQuery: ( sender, submission ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
+        ?submission a meb:Submission;
+          pav:createdBy ?sender;
+          prov:generated ?formData.
+
+        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
+
+         VALUES ?bestuurseenheid {
+           ${sparqlEscapeUri(sender)}
+         }
+
+        BIND(<http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> as ?worshipType)
+        BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> as ?worshipClassification)
+
+        ?bestuurseenheid a ?worshipType ;
+          mu:uuid ?uuid;
+          besluit:classificatie ?worshipClassification;
+          skos:prefLabel ?label.
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/wijziging-gebiedsomschrijving.js
+++ b/dispatch-rules/wijziging-gebiedsomschrijving.js
@@ -1,0 +1,51 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+/* Excel: Rules number: 143
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+**/
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b', // Wijziging gebiedsomschrijving
+  matchSentByEenheidClass: eenheidClass =>
+    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO
+  destinationInfoQuery: ( sender, submission ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
+        ?submission a meb:Submission;
+          pav:createdBy ?sender;
+          prov:generated ?formData.
+
+        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
+
+         VALUES ?bestuurseenheid {
+           ${sparqlEscapeUri(sender)}
+         }
+
+        BIND(<http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan> as ?worshipType)
+        BIND(<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213> as ?worshipClassification)
+
+        ?bestuurseenheid a ?worshipType ;
+          mu:uuid ?uuid;
+          besluit:classificatie ?worshipClassification;
+          skos:prefLabel ?label.
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;


### PR DESCRIPTION
# Description
DL-5333

This PR fixes the issue where RO's specific decisionsTypes should be dispatched in app-worship-decisions-database.

Decisions : 
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a", // Samenvoeging (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73", // Erkenning - reguliere procedure (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777", // Naamswijziging (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b", // Wijziging gebiedsomschrijving (RO)
- "https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e"  // Opheffing van annexe kerken en kapelanijen (RO)


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related Apps

- app-digitaal-loket
- app-worship-decisions-database

# How to test 

1. Create submissions from the list with a RO (e.g : Bisdom Antwerpen) in loket
2. Log prepare-submissions-for-export-service to check any trace of these submissions
3. You can also log the delta producer services for worship-submissions if they're correctly flowing
4. Consume it in worship decisions database with the following service worship-submissions-graph-dispatcher-service @ branch `fix/add-missing-ro-decisions`
5. Log with your RO to see the submission in the data table

Expected : 

![Screenshot 2023-09-13 at 10-15-39 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/31391637-17c0-49d2-a77f-ec5c00e3b504)


# Links to other PR's

- https://github.com/lblod/prepare-submissions-for-export-service/pull/9

# Notes

Bump service in app-worship-decisions-database when merged and drc up -d
