### PR TITLE
[ Worship-forms ] Adding dispatch rules for new worship forms

### DIFF
--- a/dispatch-rules/aanvraag-desaffectatie-presbyteria-kerken.js
+++ b/dispatch-rules/aanvraag-desaffectatie-presbyteria-kerken.js
@@ -1,0 +1,38 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+
+/* Excel: Rules number: TODO: Add rule number
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * Gemeente : <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ **/
+let rule = {
+  documentType:
+    "https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", // Aanvraag desaffectatie presbyteria/kerken
+  matchSentByEenheidClass: (eenheidClass) =>
+    eenheidClass ==
+    "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001",
+  destinationInfoQuery: (sender) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+          VALUES ?bestuurseenheid {
+            <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+            ${sparqlEscapeUri(sender)}
+          }
+          ?bestuurseenheid mu:uuid ?uuid;
+            skos:prefLabel ?label.
+      }
+    `;
+  },
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -1,5 +1,5 @@
 import { sparqlEscapeUri } from "mu";
-import { toezichthoudendeQuerySnippet, repOrgQuerySnippet } from './query-snippets';
+import { toezichthoudendeQuerySnippet } from "./query-snippets";
 
 const rules = [];
 
@@ -10,27 +10,26 @@ const rules = [];
 * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> CKB Deinze
 **/
 let rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget(wijziging)
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b', // Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan - EB met CB 
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB
   destinationInfoQuery: ( sender ) => {
     return `
         PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
             ?bestuurseenheid org:hasSubOrganization ?sender;
-            <http://data.vlaanderen.be/ns/besluit#classificatie>
-              <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
               skos:prefLabel ?label;
               mu:uuid ?uuid.
 
             FILTER EXISTS {
-              ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             }
           } UNION {
             VALUES ?bestuurseenheid {
@@ -41,9 +40,8 @@ let rule = {
               mu:uuid ?uuid.
 
             FILTER EXISTS {
-              ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
             }
           }
         }
@@ -52,43 +50,89 @@ let rule = {
 };
 rules.push(rule);
 
-/* Excel: Rules number: 84, 90, 91
+/* Excel: Rules number: 84, 163
 * Testing:
 *--------------------------
 * -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> Protestantse Kerk Christengemeente Emmanuel van Haacht
 * RO: <http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc> Administratieve Raad van de Protestants-Evangelische Eredienst
+* PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget(wijziging)
-  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB zonder CB
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b', // Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan - EB zonder CB
+  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB zonder CB
   destinationInfoQuery: ( sender ) => {
     return `
         PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+        SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+          BIND(${sparqlEscapeUri(sender)} as ?sender)
+          {
+            FILTER NOT EXISTS {
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+            }
+          } UNION {
+            ?bestuurseenheid org:linkedTo ?sender ;
+              mu:uuid ?uuid ;
+              skos:prefLabel ?label;
+              a ere:RepresentatiefOrgaan.
+
+            FILTER NOT EXISTS {
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+            }
+          } UNION {
+            VALUES ?bestuurseenheid {
+              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+              ${sparqlEscapeUri(sender)}
+            }
+
+            ?bestuurseenheid skos:prefLabel ?label;
+              mu:uuid ?uuid.
+
+            FILTER NOT EXISTS {
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+            }
+          }
+        }
+    `;
+  }
+};
+rules.push(rule);
+
+/* Excel: Rules number: 90, 91, 146
+* Testing:
+*--------------------------
+* -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> Protestantse Kerk Christengemeente Emmanuel van Haacht
+* Gemeente : <http://data.lblod.info/id/bestuurseenheden/b942231860865ab0c4108651b117f69a755a04186df97e767707e5d95955ebbd> Boortmeerbeek
+* PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+**/
+rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d85218e2-a75f-4a30-9182-512b5c9dd1b2', // Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie - EB zonder CB
+  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB zonder CB
+  destinationInfoQuery: ( sender ) => {
+    return `
+        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+        PREFIX org: <http://www.w3.org/ns/org#>
+        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
             ${toezichthoudendeQuerySnippet()}
             FILTER NOT EXISTS {
-              ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
-            }
-          } UNION {
-            ?bestuurseenheid org:linkedTo ?sender ;
-              mu:uuid ?uuid ;
-              skos:prefLabel ?label;
-              a <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>.
-
-            FILTER NOT EXISTS {
-              ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           } UNION {
             VALUES ?bestuurseenheid {
+              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
               ${sparqlEscapeUri(sender)}
             }
 
@@ -96,9 +140,8 @@ rule = {
               mu:uuid ?uuid.
 
             FILTER NOT EXISTS {
-              ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
-                <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+              ?cb org:hasSubOrganization ?sender;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
             }
           }
         }
@@ -107,15 +150,15 @@ rule = {
 };
 rules.push(rule);
 
-/* Excel: Rules number: 85, 88, 89
+/* Excel: Rule number: 88, 89, 145
 * Testing:
 *--------------------------
 * -SENDER-: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b0ffe0e981a7e887a0b949d7ff77096b> CKB Tongeren
 * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625> Tongeren
-* RO: <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> Bisdom Hasselt
+* PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349', // Budget(wijziging) - CB namens EB's
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29', // Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {
     return `
@@ -126,9 +169,43 @@ rule = {
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
-            ${toezichthoudendeQuerySnippet()}
+            ${toezichthoudendeQuerySnippet()} 
           } UNION {
             VALUES ?bestuurseenheid {
+              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+              ${sparqlEscapeUri(sender)}
+            }
+            ?bestuurseenheid mu:uuid ?uuid;
+              skos:prefLabel ?label.
+          }
+        }
+    `;
+  }
+};
+rules.push(rule);
+
+/* Excel: Rules number: 85, 164
+* Testing:
+*--------------------------
+* -SENDER-: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b0ffe0e981a7e887a0b949d7ff77096b> CKB Tongeren
+* RO: <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> Bisdom Hasselt
+* PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+*/
+rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349', // Budgetten(wijzigingen) - betreffende besturen van de eredienst - Indiening bij Representatief orgaan - CB namens EB's
+  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
+  destinationInfoQuery: ( sender ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+          {
+            VALUES ?bestuurseenheid {
+              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
               ${sparqlEscapeUri(sender)}
             }
             ?bestuurseenheid mu:uuid ?uuid;
@@ -137,7 +214,7 @@ rule = {
             ?bestuurseenheid org:linkedTo ?sender ;
               mu:uuid ?uuid ;
               skos:prefLabel ?label;
-              a <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>.
+              a ere:RepresentatiefOrgaan.
           }
         }
     `;

--- a/dispatch-rules/entrypoint.js
+++ b/dispatch-rules/entrypoint.js
@@ -12,6 +12,9 @@ import adviesMeerjarenplanwijzigingRules from './advies-meerjarenplanwijziging';
 
 import besluitMeerjarenplanwijzigingRules from './besluit-meerjarenplanwijziging';
 
+import aanvraagDesaffectatiePresbyteriaKerken from './aanvraag-desaffectatie-presbyteria-kerken';
+import opvragenBijkomendeInlichtingenEredienstbesturen from './opvragen-bijkomende-inlichtingen-eredienstbesturen';
+import reactieOpOpvragenBijkomendeInlichtingenDoorDeToezichthouderAanEeEredienstbesturen from './reactie-op-opvragen-bijkomende-inlichtingen-door-de-toezichthouder-aan-de-eredienstbesturen';
 /*
  * This file exports a list of rule objects, which helps deduce who the targets are for a
  * a specific submission.
@@ -41,7 +44,10 @@ const rules = [
   ...besluitBudgetwijzigingRules,
   ...meerjarenplanwijzigingRules,
   ...adviesMeerjarenplanwijzigingRules,
-  ...besluitMeerjarenplanwijzigingRules
+  ...besluitMeerjarenplanwijzigingRules,
+  ...aanvraagDesaffectatiePresbyteriaKerken,
+  ...opvragenBijkomendeInlichtingenEredienstbesturen,
+  ...reactieOpOpvragenBijkomendeInlichtingenDoorDeToezichthouderAanEeEredienstbesturen
 ];
 
 export default rules;

--- a/dispatch-rules/opvragen-bijkomende-inlichtingen-eredienstbesturen.js
+++ b/dispatch-rules/opvragen-bijkomende-inlichtingen-eredienstbesturen.js
@@ -1,0 +1,87 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+
+
+/* Excel: Rules number: TODO: Add rule number
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * Testing:
+ *--------------------------
+ * -SENDER-: <https://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+**/
+
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/24743b26-e0fb-4c14-8c82-5cd271289b0e', // Opvragen bijkomende inlichtingen eredienstbesturen
+  matchSentByEenheidClass: eenheidClass => {
+    return [
+        'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000', // Provincie
+        'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001' // Gemeente
+    ]
+      .indexOf(eenheidClass) > -1 ;
+  },
+  destinationInfoQuery: ( sender, submission ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
+        ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+          <http://purl.org/pav/createdBy> ?sender;
+          <http://www.w3.org/ns/prov#generated> ?formData.
+
+        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+          <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
+
+        VALUES ?worshipType {
+          <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+          <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+        }
+
+        VALUES ?worshipClassifications {
+          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+        }
+
+        ?aboutEenheid a ?worshipType;
+          <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+
+       {
+         ?aboutEenheid mu:uuid ?uuid;
+           skos:prefLabel ?label.
+         BIND(?aboutEenheid as ?bestuurseenheid)
+        } UNION {
+          VALUES ?bestuurseenheid {
+            ${sparqlEscapeUri(sender)}
+          }
+          ?bestuurseenheid mu:uuid ?uuid;
+           skos:prefLabel ?label.
+       } UNION {
+         ?aboutEenheid a <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>.
+
+         ?bestuurseenheid a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>;
+            <http://www.w3.org/ns/org#hasSubOrganization> ?aboutEenheid;
+            skos:prefLabel ?label;
+            mu:uuid ?uuid.
+       } UNION {
+          ?aboutEenheid a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>;
+            <http://www.w3.org/ns/org#hasSubOrganization> ?bestuurseenheid.
+ 
+          ?bestuurseenheid a <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>;
+             skos:prefLabel ?label;
+             mu:uuid ?uuid.
+        }
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/reactie-op-opvragen-bijkomende-inlichtingen-door-de-toezichthouder-aan-de-eredienstbesturen.js
+++ b/dispatch-rules/reactie-op-opvragen-bijkomende-inlichtingen-door-de-toezichthouder-aan-de-eredienstbesturen.js
@@ -1,0 +1,65 @@
+import { sparqlEscapeUri } from "mu";
+import { toezichthoudendeQuerySnippet } from './query-snippets';
+
+const rules = [];
+
+
+/* Excel: Rules number: TODO: Add rule number
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * PROVINCIE: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4> Aalst
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * PROVINCIE: <https://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+**/
+
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/3a3ea43f-6631-4a7d-94c6-3a77a445d450', // Reactie op opvragen bijkomende inlichtingen door de toezichthouder (gemeente/provincie) aan de eredienstbesturen
+  matchSentByEenheidClass: eenheidClass => {
+    return [
+        'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
+        'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054' // Centraal bestuur van de eredienst 
+    ]
+      .indexOf(eenheidClass) > -1 ;
+  },
+  destinationInfoQuery: ( sender ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        {
+          ${toezichthoudendeQuerySnippet()}
+        } UNION {
+          VALUES ?bestuurseenheid {
+            ${sparqlEscapeUri(sender)}
+          }
+          ?bestuurseenheid mu:uuid ?uuid;
+          skos:prefLabel ?label. 
+        }
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;


### PR DESCRIPTION
# Description
DL-5185 & DL-5186 & DL-5187

This PR adds dispatch rules for the following forms  : 

- Aanvraag desaffectatie presbyteria/kerken 

- Reactie op opvragen bijkomende inlichtingen door de toezichthouder (gemeente/provincie) aan de eredienstbesturen 

- Opvragen bijkomende inlichtingen eredienstbesturen (met als gevolg stuiting termijn) 


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related Apps

- app-digitaal-loket
- app-worship-decisions-database
- app-public-decisions-database
- app-toezicht-abb
- app-meldingsplichtige-api

# Related Services

- prepare-submissions-for-export-service
- enrich-submission-service
- worship-submissions-graph-dispatcher-service

# Links to other PR's

- https://github.com/lblod/manage-submission-form-tooling/pull/38
- https://github.com/lblod/app-toezicht-abb/pull/32
- https://github.com/lblod/app-meldingsplichtige-api/pull/34
- https://github.com/lblod/app-public-decisions-database/pull/19
- https://github.com/lblod/app-digitaal-loket/pull/454
- https://github.com/lblod/app-worship-decisions-database/pull/47

# Notes
Release + Bump service in app-worship-decisions-database 
