### PR TITLE
Adjusting the advies budgetwijziging rule

### DIFF
--- a/dispatch-rules/advies-budgetwijziging.js
+++ b/dispatch-rules/advies-budgetwijziging.js
@@ -43,18 +43,8 @@ let rule = {
           ?centraalBestuurVanDeEredienst org:hasSubOrganization ?aboutEenheid.
         }
 
-        VALUES ?worshipType {
-          ere:CentraalBestuurVanDeEredienst
-          ere:BestuurVanDeEredienst
-        }
-
-        VALUES ?worshipClassifications {
-          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
-          <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
-        }
-
-        ?aboutEenheid a ?worshipType;
-          besluit:classificatie ?worshipClassifications.
+        ?aboutEenheid a ere:BestuurVanDeEredienst;
+          besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>.
 
         BIND (IF(BOUND(?centraalBestuurVanDeEredienst), ?centraalBestuurVanDeEredienst, ?aboutEenheid) AS ?receiver)
        {

--- a/dispatch-rules/advies-budgetwijziging.js
+++ b/dispatch-rules/advies-budgetwijziging.js
@@ -1,5 +1,4 @@
 import { sparqlEscapeUri } from "mu";
-import { toezichthoudendeQuerySnippet, repOrgQuerySnippet } from './query-snippets';
 
 const rules = [];
 /* Excel: Rules number: 86, 87
@@ -8,31 +7,45 @@ const rules = [];
  * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
  * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
  * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e17dabfaf8f562ad181f422006c42e97> CB van de Islamitische gemeenschappen in Limburg
+ * OR
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
 **/
 let rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6', // Avies budgetwijziging
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6', // Avies budgetwijziging - EB if EB without CB or CB if EB has CB
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO
   destinationInfoQuery: ( sender, submission ) => {
     return `
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
       PREFIX org: <http://www.w3.org/ns/org#>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+      PREFIX eli: <http://data.europa.eu/eli/ontology#>
+      PREFIX pav: <http://purl.org/pav/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
 
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
-          <http://purl.org/pav/createdBy> ?sender;
-          <http://www.w3.org/ns/prov#generated> ?formData.
+        ?submission a meb:Submission;
+          pav:createdBy ?sender;
+          prov:generated ?formData.
 
         ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
-          <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
+          eli:is_about ?aboutEenheid.      
+
+        OPTIONAL {
+          ?centraalBestuurVanDeEredienst org:hasSubOrganization ?aboutEenheid.
+        }
 
         VALUES ?worshipType {
-          <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
-          <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+          ere:CentraalBestuurVanDeEredienst
+          ere:BestuurVanDeEredienst
         }
 
         VALUES ?worshipClassifications {
@@ -41,12 +54,13 @@ let rule = {
         }
 
         ?aboutEenheid a ?worshipType;
-          <http://data.vlaanderen.be/ns/besluit#classificatie> ?worshipClassifications.
+          besluit:classificatie ?worshipClassifications.
 
+        BIND (IF(BOUND(?centraalBestuurVanDeEredienst), ?centraalBestuurVanDeEredienst, ?aboutEenheid) AS ?receiver)
        {
-         ?aboutEenheid mu:uuid ?uuid;
-           skos:prefLabel ?label.
-         BIND(?aboutEenheid as ?bestuurseenheid)
+        ?receiver mu:uuid ?uuid;
+          skos:prefLabel ?label.
+        BIND(?receiver AS ?bestuurseenheid)
        } UNION {
          VALUES ?bestuurseenheid {
            ${sparqlEscapeUri(sender)}


### PR DESCRIPTION
# Description
DL-5363 & DL-5145

This PR addresses the issue where the submission with the decision type of "advies budget(wijziging)" is not correctly been dispatched.

RO should receive the submission anyway in all cases, but if submissions with receiver EB (aboutEenheid) has no CB we send it to the EB. Submissions where receiver CB has EB, it should go to CB.


# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related stack

- app-worship-decisions-database

# How to test 

1. Create a submission with RO in loket, pick a EB (e.g : St. Michiel Ichtegem ) with CB and EB (e.g : Kerkfabriek St.-Franciscus van Assisië as RO Brugge ) without CB in the field “Betreffend bestuur van de eredienst”
2. Consume it in erediensten databank aka worship-decisions-database
3. EB with CB should send the submission to CKB Ichtegem and EB without CB to Kerkfabriek St.-Franciscus van Assisië

# What to check

- N/A

# Links to other PR's

- N/A

# Notes


