### PR TITLE
Restoring budget dispatching rules for old budget submissions

### DIFF
--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -246,11 +246,6 @@ rule = {
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         {
-          FILTER NOT EXISTS {
-            ?centraalBestuur org:hasSubOrganization ?sender ;
-              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bentraalBestuur-f650b0604054> .
-          }
-        } UNION {
           ?bestuurseenheid org:linkedTo ?sender ;
             mu:uuid ?uuid ;
             skos:prefLabel ?label ;
@@ -300,12 +295,8 @@ rule = {
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         {
-          FILTER EXISTS {
-            ?centraalBestuur org:hasSubOrganization ?sender ;
-              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
-          }
-        } UNION {
           ?bestuurseenheid org:hasSubOrganization ?sender ;
+            besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
             mu:uuid ?uuid ;
             skos:prefLabel ?label ;
             a ere:CentraalBestuurVanDeEredienst  .
@@ -316,11 +307,6 @@ rule = {
 
           ?bestuurseenheid skos:prefLabel ?label ;
             mu:uuid ?uuid.
-
-          FILTER EXISTS {
-            ?centraalBestuur org:hasSubOrganization ?sender ;
-              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
-          }
         }
       }
     `;

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -222,4 +222,115 @@ rule = {
 };
 rules.push(rule);
 
+
+/**
+ * Previous form named Budget, see (https://github.com/lblod/manage-submission-form-tooling/blob/master/formSkeleton/forms/Budget/besturen-van-de-eredienst/form.ttl)
+ * was used but this form doesn't exist anymore for worship services, it has been replaced by Budget(wijziging) - Indiening bij centraal bestuur of representatief orgaan 
+ * We still need to add dispatching rules for this Budget form because of old submissions that were created. As they don't share the same form structure and URI's they serve the same purpose.
+ * Rules : Sender EB with CB = receiver EB and CB / Sender EB without CB = receiver EB and RO + ABB
+*/
+
+/*
+* Testing:
+*--------------------------
+* -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> Protestantse Kerk Christengemeente Emmanuel van Haacht
+* RO: <http://data.lblod.info/id/representatieveOrganen/6f79a1b89678b85009484da7c4a104bc> Administratieve Raad van de Protestants-Evangelische Eredienst
+* PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+*/
+rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget EB without CB
+  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
+  destinationInfoQuery: ( sender ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+      PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        {
+          FILTER NOT EXISTS {
+            ?centraalBestuur org:hasSubOrganization ?sender ;
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bentraalBestuur-f650b0604054> .
+          }
+        } UNION {
+          ?bestuurseenheid org:linkedTo ?sender ;
+            mu:uuid ?uuid ;
+            skos:prefLabel ?label ;
+            a ere:RepresentatiefOrgaan .
+
+          FILTER NOT EXISTS {
+            ?centraalBestuur org:hasSubOrganization ?sender ;
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+          }
+        } UNION {
+          VALUES ?bestuurseenheid {
+            <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+            ${sparqlEscapeUri(sender)}
+          }
+
+          ?bestuurseenheid skos:prefLabel ?label ;
+            mu:uuid ?uuid.
+
+          FILTER NOT EXISTS {
+            ?centraalBestuur org:hasSubOrganization ?sender ;
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+          }
+        }
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+/*
+* Testing:
+*--------------------------
+* -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+* CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> CKB Deinze
+*/
+rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget EB with CB
+  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
+  destinationInfoQuery: ( sender ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+      PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        {
+          FILTER EXISTS {
+            ?centraalBestuur org:hasSubOrganization ?sender ;
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+          }
+        } UNION {
+          ?bestuurseenheid org:hasSubOrganization ?sender ;
+            mu:uuid ?uuid ;
+            skos:prefLabel ?label ;
+            a ere:CentraalBestuurVanDeEredienst  .
+        } UNION {
+          VALUES ?bestuurseenheid {
+            ${sparqlEscapeUri(sender)}
+          }
+
+          ?bestuurseenheid skos:prefLabel ?label ;
+            mu:uuid ?uuid.
+
+          FILTER EXISTS {
+            ?centraalBestuur org:hasSubOrganization ?sender ;
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+          }
+        }
+      }
+    `;
+  }
+};
+rules.push(rule);
+
 export default rules;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worship-submissions-graph-dispatcher-service",
-  "version": "0.10.0",
+  "version": "0.11.0-rc.1",
   "description": "Microservice moves meb:Submissions to correct org graph.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

DL-5452

This PR restores the missing rules for Budget besluitType of worship submissions.

Bestuur Van De Eredienst can't send anymore submissions under the name of Budget, it has been replaced by Budget(wijziging) - Indiening bij centraal bestuur of representatief orgaan, therefore these old submissions were shared by the producer app and consumed in the worship decision database so involved bodies could consult them. This fixes the healing process for old submissions named Budget allowing them to be dispatched again.

Rules : Sender EB with CB = receiver EB and CB / Sender EB without CB = receiver EB and RO + ABB

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

Make sure you have data from QA or PROD

1. Use the image `v0.11.0-rc.1` and add it in the docker-compose.override.yml of app-worship-decisions-database
2. Also add into the submissions-dispatcher service `ENABLE_HEALING: "true"` and set a `HEALING_CRON`
3. Log the service and let the healing run
4. You can now check if submissions under this URI `<https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873>` are dispatched into the correct graphs

To find receivers from rules of EB with/without CB you can use this query on CVP at https://data.lblod.info/sparql

```sparql
PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
PREFIX org: <http://www.w3.org/ns/org#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

SELECT DISTINCT
  ?bestuurseenheidUri
  ?bestuurseenheidLabel
  ?betrokkenLocaleBesturenUri
  ?typeBetrokkenheid
  ?relatedEredienstOrganisationUri
  ?relatedEredienstOrganisationLabel
  ?subOrganisation
  ?linkedToEredienstBestuurUri
  ?linkedToEredienstBestuurLabel


WHERE {
  BIND (<http://data.lblod.info/id/besturenVanDeEredienst/UUID_OF_BESTUREN_VAN_DE_EREDIENST> AS ?relatedEredienstOrganisationUri)

  ?bestuurseenheidUri ere:betrokkenBestuur ?betrokkenLocaleBesturenUri ;
                      skos:prefLabel ?bestuurseenheidLabel .
  
  ?betrokkenLocaleBesturenUri ere:typebetrokkenheid ?involvmentType .
  VALUES (?medefinancierend ?toezichthoudend ?adviserend) { 
    (
      <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e>
      <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
      <http://lblod.data.gift/concepts/0f845f00ee76099c89518cbaf6a7b77f>
    )
  }

  BIND (
    IF(?involvmentType = ?toezichthoudend, "Toezichthoudend",
    IF(?involvmentType = ?medefinancierend, "Mede-finencierend",
    IF(?involvmentType = ?adviserend, "Adviserend", "Not Found")
    )) AS ?typeBetrokkenheid
  )

  ?betrokkenLocaleBesturenUri org:organization ?relatedEredienstOrganisationUri .
  ?relatedEredienstOrganisationUri ^org:linkedTo ?linkedToEredienstBestuurUri ;
                                   skos:prefLabel ?relatedEredienstOrganisationLabel .

  ?linkedToEredienstBestuurUri skos:prefLabel ?linkedToEredienstBestuurLabel .
  
  OPTIONAL { ?centralBestuurURI org:hasSubOrganization ?relatedEredienstOrganisationUri .}
  
  OPTIONAL { ?relatedEredienstOrganisationUri a ?typeEredienstUri .}
  
  BIND (
    IF(BOUND(?centralBestuurURI), "has CB", IF(?typeEredienstUri = ere:CentraalBestuurVanDeEredienst, "is CB", "no CB")) AS ?subOrganisation
  )

}
```
 
# What to check

- N/A

# Links to other PR's

- worship-decisions-database

# Notes

Release + Bump on worship decisions database