### PR TITLE
Update query

### DIFF
--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -71,11 +71,6 @@ rule = {
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
-            FILTER NOT EXISTS {
-              ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
-            }
-          } UNION {
             ?bestuurseenheid org:linkedTo ?sender ;
               mu:uuid ?uuid ;
               skos:prefLabel ?label;


### PR DESCRIPTION
The part removed, if sender has no CB, will return a resultset. Consider the selected terms `?bestuurseenheid ?uuid ?label` as a filter on the variables of the result set. And these will return nothing.

Best is to compare e.g. the results of

```
        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
        PREFIX org: <http://www.w3.org/ns/org#>
        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
        PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>

        SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
          BIND(<http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab> as ?sender)
          {
            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          } UNION {
            ?bestuurseenheid org:linkedTo ?sender ;
              mu:uuid ?uuid ;
              skos:prefLabel ?label;
              a ere:RepresentatiefOrgaan.

            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          } UNION {
            VALUES ?bestuurseenheid {
              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
              <http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab>
            }

            ?bestuurseenheid skos:prefLabel ?label;
              mu:uuid ?uuid.

            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          }
        }
```
Which looks like it doesn't return results (but in fact it returns a resultset, just not with empty values for the asked variables.

But add a count and you'll see '1' appear.

```
        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
        PREFIX org: <http://www.w3.org/ns/org#>
        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
        PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>

        SELECT COUNT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
          BIND(<http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab> as ?sender)
          {
            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          } UNION {
            ?bestuurseenheid org:linkedTo ?sender ;
              mu:uuid ?uuid ;
              skos:prefLabel ?label;
              a ere:RepresentatiefOrgaan.

            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          } UNION {
            VALUES ?bestuurseenheid {
              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
              <http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab>
            }

            ?bestuurseenheid skos:prefLabel ?label;
              mu:uuid ?uuid.

            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          }
        }
```
and finally if you do

```
        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
        PREFIX org: <http://www.w3.org/ns/org#>
        PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
        PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
        PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>

        SELECT DISTINCT * WHERE {
          BIND(<http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab> as ?sender)
          {
            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          } UNION {
            ?bestuurseenheid org:linkedTo ?sender ;
              mu:uuid ?uuid ;
              skos:prefLabel ?label;
              a ere:RepresentatiefOrgaan.

            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          } UNION {
            VALUES ?bestuurseenheid {
              <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
              <http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab>
            }

            ?bestuurseenheid skos:prefLabel ?label;
              mu:uuid ?uuid.

            FILTER NOT EXISTS {
              ?cb org:hasSubOrganization ?sender;
                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
            }
          }
        }
```
You will see bound variables pop up.

So the `parseResult` function for the intial call, see an array with size 1 coming in, but all attributes being 'undefined' and that's why we eventually en up in `<http://mu.semte.ch/graphs/organizations/undefined/LoketLB-databankEredienstenGebruiker>`