### PR TITLE
Adding new dispatch rules for "Melding onvolledigheid inzending eredienstbestuur" and "Opstart beroepsprocedure naar aanleiding van een beslissing" forms

### DIFF
--- a/dispatch-rules/entrypoint.js
+++ b/dispatch-rules/entrypoint.js
@@ -18,6 +18,8 @@ import naamswijziging from './naamswijziging';
 import opheffingVanAnnexeKerkenEnKapelanijen from './opheffing-van-annexe-kerken-en-kapelanijen';
 import wijzigingGebiedsomschrijving from './wijziging-gebiedsomschrijving';
 import samenvoeging from './samenvoeging';
+import meldingOnvolledigheidInzendingEredienstbestuur from './melding-onvolledigheid-inzending-eredienstbestuur';
+import opstartBeroepsprocedureNaarAanleidingVanEenBeslissing from './opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing';
 
 /*
  * This file exports a list of rule objects, which helps deduce who the targets are for a
@@ -56,7 +58,9 @@ const rules = [
   ...naamswijziging,
   ...opheffingVanAnnexeKerkenEnKapelanijen,
   ...samenvoeging,
-  ...wijzigingGebiedsomschrijving
+  ...wijzigingGebiedsomschrijving,
+  ...meldingOnvolledigheidInzendingEredienstbestuur,
+  ...opstartBeroepsprocedureNaarAanleidingVanEenBeslissing
 ];
 
 export default rules;

--- a/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
+++ b/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
@@ -1,0 +1,69 @@
+import { sparqlEscapeUri } from "mu";
+import { toezichthoudendeQuerySnippet } from "./query-snippets";
+
+const rules = [];
+
+/* Excel:
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB 
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * PROVINCIE: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4> Aalst
+ * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4> Aalst
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ * 
+ *  * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * PROVINCIE: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ **/
+let rule = {
+  documentType:
+    "https://data.vlaanderen.be/id/concept/BesluitDocumentType/863caf68-97c9-4ee0-adb5-620577ea8146", // Melding onvolledigheid inzending eredienstbestuur
+    matchSentByEenheidClass: eenheidClass => {
+        return [
+            'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000', // Provincie
+            'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001'  // Gemeente
+        ]
+          .indexOf(eenheidClass) > -1 ; 
+    },
+    destinationInfoQuery: (sender) => {
+        return `
+          PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+          PREFIX org: <http://www.w3.org/ns/org#>
+          PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+          SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+            BIND(${sparqlEscapeUri(sender)} as ?sender)
+            {
+              ${toezichthoudendeQuerySnippet()}
+            } UNION {
+              VALUES ?bestuurseenheid {
+                <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+                ${sparqlEscapeUri(sender)}
+              }
+              ?bestuurseenheid mu:uuid ?uuid;
+                skos:prefLabel ?label.
+            }
+          }
+        `;
+    },
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing.js
+++ b/dispatch-rules/opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing.js
@@ -1,0 +1,69 @@
+import { sparqlEscapeUri } from "mu";
+
+const rules = [];
+
+/* Excel:
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Deinze
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB 
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * PROVINCIE: <http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa> Oost-Vlaanderen
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> Kerkfabriek O.-L.-Vrouw van Deinze
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ * 
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ **/
+let rule = {
+  documentType:
+    "https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae", // Opstart beroepsprocedure naar aanleiding van een beslissing
+    matchSentByEenheidClass: eenheidClass => {
+        return [
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000', // Provincie
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001', // Gemeente
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213'  // Representatief Orgaan
+        ]
+          .indexOf(eenheidClass) > -1 ; 
+    },
+    destinationInfoQuery: (sender) => {
+        return `
+          PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+          PREFIX org: <http://www.w3.org/ns/org#>
+          PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+          SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+            BIND(${sparqlEscapeUri(sender)} as ?sender)
+              VALUES ?bestuurseenheid {
+                <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+                ${sparqlEscapeUri(sender)}
+              }
+              ?bestuurseenheid mu:uuid ?uuid;
+                skos:prefLabel ?label.
+          }
+        `;
+    },
+};
+rules.push(rule);
+
+export default rules;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worship-submissions-graph-dispatcher-service",
-  "version": "0.12.0-rc.1",
+  "version": "0.12.0-rc.2",
   "description": "Microservice moves meb:Submissions to correct org graph.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worship-submissions-graph-dispatcher-service",
-  "version": "0.11.0",
+  "version": "0.12.0-rc.1",
   "description": "Microservice moves meb:Submissions to correct org graph.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

DL-5643 - DL-5646

This PR adds new rules for the newly added forms "Melding onvolledigheid inzending eredienstbestuur" and "Opstart beroepsprocedure naar aanleiding van een beslissing".

- "Melding onvolledigheid inzending eredienstbestuur" Sender ->  "Gemeente" and "Provincie" 
Receivers = Made by Gemeente OR Provincie / EB or CB selected in the form / ABB
- "Opstart beroepsprocedure naar aanleiding van een beslissing" Sender -> "Gemeenten", "Provincies", "Bestuur van de eredienst", "Centraal bestuur van de eredienst" and "Representatief Orgaan"
Receivers = Made by Gemeenten, Provincies, Bestuur van de eredienst, Centraal bestuur van de eredienst OR Representatief Orgaan / ABB

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Create these submissions in Loket
2. Connect the two stacks and check the logs of the consumer service and the submission-dispatcher service
3. Submissions should flow through based on the rules 

### Melding onvolledigheid inzending eredienstbestuur

Expected to flow through 

#### ABB
![Screenshot 2024-02-23 at 13-08-19 Erediensten Toezichtsdatabank-abb](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/a7147448-c768-4b2e-81d2-a3e366d85f36)

#### Gemeente Aalst
![Screenshot 2024-02-23 at 13-09-08 Erediensten Toezichtsdatabank-aalst](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/b1947b03-bae6-403c-ae5e-71f1c3b9fd4d)

#### Selected Eredienst Bestuur (Kerkfabriek H. Hart van Aalst)

![Screenshot 2024-02-23 at 13-07-30 Erediensten Toezichtsdatabank-h-hart-van-aalst](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/eeae7945-7807-4a06-9820-b9909bba4bff)

### Opstart beroepsprocedure naar aanleiding van een beslissing

#### ABB
![Screenshot 2024-02-23 at 12-10-12 Erediensten Toezichtsdatabank-abb](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/fa486d1b-7efb-4e7e-8e82-ed9ae1ea2765)

#### Gemeente Aalst
![Screenshot 2024-02-23 at 12-11-44 Erediensten Toezichtsdatabank-aalst](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/2ad2966a-9e32-4c17-a9b1-aae84bca39be)

 
# What to check

- Manage-submissions-form-tooling -> https://github.com/lblod/manage-submission-form-tooling/pull/44
- App-digitaal-loket -> https://github.com/lblod/app-digitaal-loket/pull/528
- App-meldingsplichtige -> https://github.com/lblod/app-meldingsplichtige-api/pull/41
- App-toezicht-ABB -> https://github.com/lblod/app-toezicht-abb/pull/38
- App-public-decisions-database -> https://github.com/lblod/app-public-decisions-database/pull/25
- App-worship-decisions-database -> https://github.com/lblod/app-worship-decisions-database/pull/59
- Prepare-submissions-for-export-service -> https://github.com/lblod/prepare-submissions-for-export-service/pull/12
- Enrich-submission-service -> https://github.com/lblod/enrich-submission-service/pull/18

# Links to other PR's

- worship-decisions-database

# Notes

Release + Bump on worship decisions database