### PR TITLE
Add new rule for form "Afschrift erkenningszoekende besturen"

### DIFF
--- a/dispatch-rules/afschrift-erkenningszoekende-besturen.js
+++ b/dispatch-rules/afschrift-erkenningszoekende-besturen.js
@@ -1,0 +1,47 @@
+import { sparqlEscapeUri } from "mu";
+import { allTypeLocaleBetrokkenheid, repOrgQuerySnippet } from './query-snippets';
+
+const rules = [];
+
+/* Excel:
+ * Testing:
+ *--------------------------
+ * -SENDER-: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
+ * GO: <http://data.lblod.info/id/bestuurseenheden/55155a78bd145df7bfa3caaa17ba491fb4dd238f4f4d2c5485bff1be96ca3036> Mol
+ * PO: <http://data.lblod.info/id/bestuurseenheden/bd74ee38a4b1e296821a11729c1f704cf439576c7ab2c910c95b067cf183d923> Prov. Antwerpen
+ * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
+ * RO: <http://data.lblod.info/id/representatieveOrganen/e224c637ba8bb0e5dfbb87da225b4652> Executief van de Moslims van België
+ * EB: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
+**/
+let rule = {
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2', // Afschrift erkenningszoekende besturen
+  matchSentByEenheidClass: (eenheidClass) =>
+    eenheidClass ==
+    'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
+  destinationInfoQuery: ( sender ) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+        {
+          ${allTypeLocaleBetrokkenheid()}
+        } UNION {
+          VALUES ?bestuurseenheid {
+            <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+            ${sparqlEscapeUri(sender)}
+          }
+          ?bestuurseenheid mu:uuid ?uuid;
+          skos:prefLabel ?label.
+        } UNION {
+          ${repOrgQuerySnippet()}
+        }
+      }
+    `;
+  }
+};
+rules.push(rule);
+
+export default rules;

--- a/dispatch-rules/entrypoint.js
+++ b/dispatch-rules/entrypoint.js
@@ -20,6 +20,7 @@ import wijzigingGebiedsomschrijving from './wijziging-gebiedsomschrijving';
 import samenvoeging from './samenvoeging';
 import meldingOnvolledigheidInzendingEredienstbestuur from './melding-onvolledigheid-inzending-eredienstbestuur';
 import opstartBeroepsprocedureNaarAanleidingVanEenBeslissing from './opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing';
+import afschriftErkenningszoekendeBesturen from './afschrift-erkenningszoekende-besturen';
 
 /*
  * This file exports a list of rule objects, which helps deduce who the targets are for a
@@ -60,7 +61,8 @@ const rules = [
   ...samenvoeging,
   ...wijzigingGebiedsomschrijving,
   ...meldingOnvolledigheidInzendingEredienstbestuur,
-  ...opstartBeroepsprocedureNaarAanleidingVanEenBeslissing
+  ...opstartBeroepsprocedureNaarAanleidingVanEenBeslissing,
+  ...afschriftErkenningszoekendeBesturen
 ];
 
 export default rules;

--- a/dispatch-rules/query-snippets.js
+++ b/dispatch-rules/query-snippets.js
@@ -1,3 +1,22 @@
+export const allTypeLocaleBetrokkenheid = () => `
+          VALUES ?classificatie {
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+          }
+          VALUES ?typeLocaleBetrokkenheid {
+            <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e>
+            <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
+            <http://lblod.data.gift/concepts/0f845f00ee76099c89518cbaf6a7b77f>
+          }
+          ?betrokkenBestuur <http://www.w3.org/ns/org#organization> ?sender;
+          <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeLocaleBetrokkenheid.
+
+          ?bestuurseenheid <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur;
+          <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
+          mu:uuid ?uuid;
+          <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+`;
+
 export const toezichthoudendeQuerySnippet = () => `
           VALUES ?classificatie {
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worship-submissions-graph-dispatcher-service",
-  "version": "0.12.0",
+  "version": "0.13.0-rc.1",
   "description": "Microservice moves meb:Submissions to correct org graph.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

DL-5670

This PR adds a new rule for "Afschrift erkenningszoekende besturen" form.

- "Afschrift erkenningszoekende besturen" Sender ->  "Bestuur van de eredienst"  
Receivers = Made by Bestuur van de eredienst / Gemeente AND/OR Provincie that have a local involvement / Representatief Orgaan / ABB

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Create these submissions in Loket
2. Connect the two stacks and check the logs of the consumer service and the submission-dispatcher service
3. Submissions should flow through based on the rules 

### Afschrift erkenningszoekende besturen

Expected to flow through 

#### ABB
![Screenshot 2024-02-27 at 12-40-45 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/65bf8024-7bbd-41af-8728-859292071847)

#### Gemeente Aalst (Toezichthoudend)
![Screenshot 2024-02-27 at 12-44-25 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/e0f4d538-3811-4510-b6e2-7f2b31ea86ab)

#### Sender Eredienst Bestuur (Kerkfabriek H. Hart van Aalst)
![Screenshot 2024-02-27 at 12-42-18 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/0e650669-0065-4a0c-a9c3-97c6b62f6844)

#### Representatief Orgaan Bisdom Gent
![Screenshot 2024-02-27 at 12-43-12 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/ed45329e-6e31-4b73-aa91-2c4c40bb8129)
 
# What to check

- N/A

# Links to other PR's

- Manage-submissions-form-tooling -> https://github.com/lblod/manage-submission-form-tooling/pull/46
- App-digitaal-loket -> https://github.com/lblod/app-digitaal-loket/pull/528
- App-meldingsplichtige -> https://github.com/lblod/app-meldingsplichtige-api/pull/41
- App-toezicht-ABB -> https://github.com/lblod/app-toezicht-abb/pull/38
- App-public-decisions-database -> https://github.com/lblod/app-public-decisions-database/pull/25
- App-worship-decisions-database -> https://github.com/lblod/app-worship-decisions-database/pull/59
- Prepare-submissions-for-export-service -> https://github.com/lblod/prepare-submissions-for-export-service/pull/13
- Enrich-submission-service -> https://github.com/lblod/enrich-submission-service/pull/19

# Notes

Release + Bump on worship decisions database