### PR TITLE
Feature/heal submission from start date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# worship-submissions-graph-dispatcher-service
+s# worship-submissions-graph-dispatcher-service
 
 Microservice that listens to the delta notifier and dispatches submissions (and related) to the correct organisation graphs.
 By correct: we mean as defined by business rules. See code for exact implementation.
@@ -50,10 +50,21 @@ ENABLE_HEALING : enables healing, defaults to false
 ## API
 ### POST /delta
 Triggers the preparation of a submission for the export when a resource is sent.
-### [DEBUG] GET /manual-dispatch?subject=http://bar
-Triggers a manual dispatch.
-Meant for debugging only.
-If no parameters are provided, will dispatch all submissions in DISPATCH_SOURCE_GRAPH.
-### [DEBUG] GET /heal-submission?subject=http://bar
-Triggers the healing of one submission, or all of them if no param is given
-Meant for debugging only.
+#### DEUBG API
+The debug API provides a set of endpoints designed to assist in troubleshooting and resolving issues related to the submission dispatch.
+Don't expose this API in production.
+##### GET `/heal-submission`
+This endpoint triggers the healing flow for submissions, clearing the submission from all its target graphs and restarting the dispatching process.
+
+**Usage:**
+- To heal a specific submission, provide `?subject=http://submissions/123`
+- To heal submissions sent from a specific sentDate, use `?sentDateSince` with the date in `YYYY-MM-DD` format.
+- If no query parameters are provided, the healing process will be applied to all submissions.
+
+#### GET `/manual-dispatch`
+
+This endpoint allows for the manual triggering of the dispatch process. It doesn't not clear data in the target graph. It does the dispatch process again.
+
+**Usage:**
+- To dispatch a specific submission, provide `?subject=http://submissions/123`
+- Without any query parameters, the endpoint will re-dispatch all submissions present in `DISPATCH_SOURCE_GRAPH`.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ ORG_GRAPH_SUFFIX : The postfix of the org-graph  defaults to 'ABB_databankEredie
 DISPATCH_SOURCE_GRAPH : The source graph of the submissions defaults to 'http://mu.semte.ch/graphs/temp/for-dispatch';
 HEALING_CRON : cron pattern for healing defaults to '00 07 * * 06'; //Weekly on saturday
 ENABLE_HEALING : enables healing, defaults to false
+NUMBER_OF_HEALING_QUEUES: the number of healing queues availible, for parallel processing purposes. Defaults to '1'
 ```
 ## API
 ### POST /delta

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ENABLE_HEALING : enables healing, defaults to false
 ## API
 ### POST /delta
 Triggers the preparation of a submission for the export when a resource is sent.
-#### DEUBG API
+#### DEBUG API
 The debug API provides a set of endpoints designed to assist in troubleshooting and resolving issues related to the submission dispatch.
 Don't expose this API in production.
 ##### GET `/heal-submission`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-s# worship-submissions-graph-dispatcher-service
+# worship-submissions-graph-dispatcher-service
 
 Microservice that listens to the delta notifier and dispatches submissions (and related) to the correct organisation graphs.
 By correct: we mean as defined by business rules. See code for exact implementation.

--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ import dispatchRules from "./dispatch-rules/entrypoint";
 import exportConfig from "./export-config";
 import { DISPATCH_SOURCE_GRAPH, ENABLE_HEALING, HEALING_CRON, ORG_GRAPH_BASE, ORG_GRAPH_SUFFIX } from './config';
 
-const processSubjectsQueue = new ProcessingQueue('submissions-dispatch-queue');
+const normalQueue = new ProcessingQueue('normal-operation-queue');
 
 console.log(`ENABLE_HEALING is set to ${ENABLE_HEALING}`);
 if(ENABLE_HEALING) {
@@ -62,7 +62,7 @@ app.post("/delta", async function (req, res) {
   const uniqueSubjects = [ ...new Set(subjects) ];
 
   for(const subject of uniqueSubjects) {
-    processSubjectsQueue.addJob(async () => await processSubject(subject));
+    normalQueue.addJob(async () => await processSubject(subject));
   }
   return res.status(200).send();
 });

--- a/app.js
+++ b/app.js
@@ -25,6 +25,8 @@ import { DISPATCH_SOURCE_GRAPH,
        } from './config';
 
 const normalQueue = new ProcessingQueue('normal-operation-queue');
+
+console.log(`The healing pool will consist of ${NUMBER_OF_HEALING_QUEUES} queues`);
 const healingQueuePool = Array.from(
   { length: NUMBER_OF_HEALING_QUEUES },
   (_, index) => new ProcessingQueue(`healing-queue-${index}`)

--- a/app.js
+++ b/app.js
@@ -72,14 +72,6 @@ app.post("/delta", async function (req, res) {
  * Not meant to be exposed
  * Note: GET calls with side effects (sorry)
  ***********************************************/
-/*
- * Triggers the dispatch manually.
- * Append only operation.
- * Uses cases:
- *  - debugging
- *  - something went wrong during the initial sync and it needs to be restarted.
- *  - something went wrong during the dispatch of a single submission
- */
 
 /**
  * Triggers the dispatch process manually.

--- a/app.js
+++ b/app.js
@@ -80,6 +80,21 @@ app.post("/delta", async function (req, res) {
  *  - something went wrong during the initial sync and it needs to be restarted.
  *  - something went wrong during the dispatch of a single submission
  */
+
+/**
+ * Triggers the dispatch process manually.
+ *  This is an operation is intended for scenarios such as debugging, restarting failed initial syncs,
+ *  or re-dispatching submissions that encountered issues during dispatching.
+ *
+ * @route GET /manual-dispatch
+ * @group Dispatch - Operations related to the manual dispatch of submissions
+ * @param {string} [subject] - The unique identifier of a specific submission to dispatch. If provided, only this submission will be re-dispatched.
+ * @returns {Object} 201 - An empty response indicating that the dispatch process has been initiated.
+ * @example request - Example of dispatching a specific submission
+ * GET /manual-dispatch?subject=sub123
+ * @example request - Example of dispatching all submissions
+ * GET /manual-dispatch
+ */
 app.get("/manual-dispatch", async function (req, res) {
   if(req.query.subject) {
     console.log(`Only one subject to (re-)dispatch: ${req.query.subject}`);
@@ -98,12 +113,21 @@ app.get("/manual-dispatch", async function (req, res) {
   return res.status(201).send();
 });
 
-/*
- * Triggers the healing flow for a single submission.
- * Clears the submission from all its target graphs, and starts the dispatching again
- * Uses cases:
- *  - debugging
- *  - something went wrong during the dispatch of a single submission
+/**
+ * Triggers the healing flow for submissions.
+ * This process clears the submission from all its target graphs and restarts the dispatching process.
+ * It's useful for debugging or when something goes wrong during the dispatch of a submission.
+ *
+ * @route GET /heal-submission
+ * @param {string} [subject] - The unique identifier of the submission to heal. If provided, only this submission will be healed.
+ * @param {string} [sentDateSince] - The start date from which submissions will be healed, in YYYY-MM-DD format.
+ *   If provided, all submissions sent on or after this date will be healed. If omitted, all submissions will be healed.
+ * @returns {Object} 201 - An empty response indicating that the healing process has been initiated.
+ * @returns {Error} 406 - An error response indicating that multiple query parameters are not supported.
+ * @example request - Example of healing a specific submission
+ * GET /heal-submission?subject=sub123
+ * @example request - Example of healing submissions from a specific date
+ * GET /heal-submission?sentDateSince=2023-01-01
  */
 app.get("/heal-submission", async function (req, res) {
 

--- a/app.js
+++ b/app.js
@@ -145,7 +145,7 @@ app.get("/heal-submission", async function (req, res) {
     let sentDateSince = new Date(req.query.sentDateSince).toISOString().split('T')[0];
     console.log(`Received "?sentDateSince" paramater: ${req.query.sentDateSince}`);
     console.log(`Converted to short date: ${sentDateSince}`);
-    console.log(`Healing will be applied submissions with sent date >= ${sentDateSince}`);
+    console.log(`Healing will be applied to submissions with sent date >= ${sentDateSince}`);
     submissions = await getSubmissions( { sentDateSince } );
   }
   else {

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import bodyParser from "body-parser";
 import { CronJob } from 'cron';
 import { app } from "mu";
 import { Delta } from "./lib/delta";
-import { ProcessingQueue } from './lib/processing-queue';
+import { ProcessingQueue, distributeAndSchedule } from './lib/processing-queue';
 import {
   sendErrorAlert,
   getTypesForSubject,
@@ -16,9 +16,19 @@ import {
 } from "./util/queries";
 import dispatchRules from "./dispatch-rules/entrypoint";
 import exportConfig from "./export-config";
-import { DISPATCH_SOURCE_GRAPH, ENABLE_HEALING, HEALING_CRON, ORG_GRAPH_BASE, ORG_GRAPH_SUFFIX } from './config';
+import { DISPATCH_SOURCE_GRAPH,
+         ENABLE_HEALING,
+         HEALING_CRON,
+         ORG_GRAPH_BASE,
+         ORG_GRAPH_SUFFIX,
+         NUMBER_OF_HEALING_QUEUES
+       } from './config';
 
 const normalQueue = new ProcessingQueue('normal-operation-queue');
+const healingQueuePool = Array.from(
+  { length: NUMBER_OF_HEALING_QUEUES },
+  (_, index) => new ProcessingQueue(`healing-queue-${index}`)
+);
 
 console.log(`ENABLE_HEALING is set to ${ENABLE_HEALING}`);
 if(ENABLE_HEALING) {
@@ -29,8 +39,10 @@ if(ENABLE_HEALING) {
 
     const submissions = await getSubmissions();
     for(const submission of submissions) {
-      processSubjectsQueue
-        .addJob(async () => await healSubmission(submission));
+      distributeAndSchedule(
+        healingQueuePool,
+        async () => await healSubmission(submission)
+      );
     }
   }, null, true);
 }
@@ -98,7 +110,10 @@ app.post("/delta", async function (req, res) {
 app.get("/manual-dispatch", async function (req, res) {
   if(req.query.subject) {
     console.log(`Only one subject to (re-)dispatch: ${req.query.subject}`);
-    processSubjectsQueue.addJob(async () => await processSubject(req.query.subject));
+    distributeAndSchedule(
+      healingQueuePool,
+      async () => await processSubject(req.query.subject)
+    );
   }
   else {
     console.log(`Dispatching all submissions (again) from GRAPH ${DISPATCH_SOURCE_GRAPH}`);
@@ -106,7 +121,10 @@ app.get("/manual-dispatch", async function (req, res) {
     console.log(`Found ${submissions.length} submissions to (re-)dispatch.`);
     console.log(`This might take a while; big amount can take big time`);
     for(const submission of submissions) {
-      processSubjectsQueue.addJob(async () => await processSubject(submission));
+      distributeAndSchedule(
+        healingQueuePool,
+        async () => await processSubject(submission)
+      );
     }
   }
   console.log(`Scheduling done`);
@@ -142,7 +160,10 @@ app.get("/heal-submission", async function (req, res) {
 
   if(req.query.subject) {
     console.log(`Only one submission to (re-)dispatch: ${req.query.subject}`);
-    processSubjectsQueue.addJob(async () => await healSubmission(req.query.subject));
+    distributeAndSchedule(
+      healingQueuePool,
+      async () => await healSubmission(req.query.subject)
+    );
     console.log(`Scheduling done`);
     return res.status(201).send();
   }
@@ -162,7 +183,10 @@ app.get("/heal-submission", async function (req, res) {
   }
 
   for(const submission of submissions) {
-    processSubjectsQueue.addJob(async () => await healSubmission(submission));
+    distributeAndSchedule(
+      healingQueuePool,
+      async () => await healSubmission(submission)
+    );
   }
 
   return res.status(201).send();

--- a/config.js
+++ b/config.js
@@ -3,4 +3,4 @@ export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankEre
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
-export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1 );
+export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1);

--- a/config.js
+++ b/config.js
@@ -3,4 +3,4 @@ export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankEre
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
-export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1);
+export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES) || 1;

--- a/config.js
+++ b/config.js
@@ -3,3 +3,4 @@ export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankEre
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
+export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1 );

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -39,3 +39,14 @@ export class ProcessingQueue {
     });
   }
 }
+export async function distributeAndSchedule(queuePool, job) {
+  const smallestQueue = queuePool.reduce(
+    (smallestQueueSoFar, currentQueue) => {
+      if(currentQueue.length < smallestQueueSoFar.length) {
+        return currentQueue;
+      }
+      return smallestQueueSoFar;
+    }, queuePool[0]);
+
+  smallestQueue.addJob(job);
+}

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -6,6 +6,10 @@ export class ProcessingQueue {
     this.executing = false; //To avoid subtle race conditions TODO: is this required?
   }
 
+  get length() {
+    return this.queue.length;
+  }
+
   async run() {
     if (this.queue.length > 0 && !this.executing) {
       const job = this.queue.shift();

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -40,6 +40,11 @@ export class ProcessingQueue {
   }
 }
 
+/**
+ * Distributes and schedules a job among a pool of queues, selecting the queue with the fewest tasks.
+ * @param {ProcessingQueue[]} queuePool - The pool of ProcessingQueue instances to choose from.
+ * @param {Function} job - The job to be added to the smallest queue.
+ */
 export async function distributeAndSchedule(queuePool, job) {
   const smallestQueue = queuePool.reduce(
     (smallestQueueSoFar, currentQueue) => {

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -39,6 +39,7 @@ export class ProcessingQueue {
     });
   }
 }
+
 export async function distributeAndSchedule(queuePool, job) {
   const smallestQueue = queuePool.reduce(
     (smallestQueueSoFar, currentQueue) => {


### PR DESCRIPTION
In some cases; we'd like to only be able to heal a subset of the submissions. This PR allows the ability to start healing for submission where sentDate >= then a provided date.

To see in in action:
```
submissions-dispatcher:
  image: lblod/worship-submissions-graph-dispatcher-service:0.13.0.rc-sentDate-1
```
Once up and running:
```
drc exec submissions-dispatcher wget http://localhost/heal-submission?sentDateSince=2023-12-13
```