### PR TITLE
Feature/parallel queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ ORG_GRAPH_SUFFIX : The postfix of the org-graph  defaults to 'ABB_databankEredie
 DISPATCH_SOURCE_GRAPH : The source graph of the submissions defaults to 'http://mu.semte.ch/graphs/temp/for-dispatch';
 HEALING_CRON : cron pattern for healing defaults to '00 07 * * 06'; //Weekly on saturday
 ENABLE_HEALING : enables healing, defaults to false
+NUMBER_OF_HEALING_QUEUES: the number of healing queues availible, for parallel processing purposes. Defaults to '1'
 ```
 ## API
 ### POST /delta

--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ import dispatchRules from "./dispatch-rules/entrypoint";
 import exportConfig from "./export-config";
 import { DISPATCH_SOURCE_GRAPH, ENABLE_HEALING, HEALING_CRON, ORG_GRAPH_BASE, ORG_GRAPH_SUFFIX } from './config';
 
-const processSubjectsQueue = new ProcessingQueue('submissions-dispatch-queue');
+const normalQueue = new ProcessingQueue('normal-operation-queue');
 
 console.log(`ENABLE_HEALING is set to ${ENABLE_HEALING}`);
 if(ENABLE_HEALING) {
@@ -62,7 +62,7 @@ app.post("/delta", async function (req, res) {
   const uniqueSubjects = [ ...new Set(subjects) ];
 
   for(const subject of uniqueSubjects) {
-    processSubjectsQueue.addJob(async () => await processSubject(subject));
+    normalQueue.addJob(async () => await processSubject(subject));
   }
   return res.status(200).send();
 });

--- a/app.js
+++ b/app.js
@@ -25,6 +25,8 @@ import { DISPATCH_SOURCE_GRAPH,
        } from './config';
 
 const normalQueue = new ProcessingQueue('normal-operation-queue');
+
+console.log(`The healing pool will consist of ${NUMBER_OF_HEALING_QUEUES} queues`);
 const healingQueuePool = Array.from(
   { length: NUMBER_OF_HEALING_QUEUES },
   (_, index) => new ProcessingQueue(`healing-queue-${index}`)

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ import bodyParser from "body-parser";
 import { CronJob } from 'cron';
 import { app } from "mu";
 import { Delta } from "./lib/delta";
-import { ProcessingQueue } from './lib/processing-queue';
+import { ProcessingQueue, distributeAndSchedule } from './lib/processing-queue';
 import {
   sendErrorAlert,
   getTypesForSubject,
@@ -16,9 +16,19 @@ import {
 } from "./util/queries";
 import dispatchRules from "./dispatch-rules/entrypoint";
 import exportConfig from "./export-config";
-import { DISPATCH_SOURCE_GRAPH, ENABLE_HEALING, HEALING_CRON, ORG_GRAPH_BASE, ORG_GRAPH_SUFFIX } from './config';
+import { DISPATCH_SOURCE_GRAPH,
+         ENABLE_HEALING,
+         HEALING_CRON,
+         ORG_GRAPH_BASE,
+         ORG_GRAPH_SUFFIX,
+         NUMBER_OF_HEALING_QUEUES
+       } from './config';
 
 const normalQueue = new ProcessingQueue('normal-operation-queue');
+const healingQueuePool = Array.from(
+  { length: NUMBER_OF_HEALING_QUEUES },
+  (_, index) => new ProcessingQueue(`healing-queue-${index}`)
+);
 
 console.log(`ENABLE_HEALING is set to ${ENABLE_HEALING}`);
 if(ENABLE_HEALING) {
@@ -29,8 +39,10 @@ if(ENABLE_HEALING) {
 
     const submissions = await getSubmissions();
     for(const submission of submissions) {
-      processSubjectsQueue
-        .addJob(async () => await healSubmission(submission));
+      distributeAndSchedule(
+        healingQueuePool,
+        async () => await healSubmission(submission)
+      );
     }
   }, null, true);
 }
@@ -98,7 +110,10 @@ app.post("/delta", async function (req, res) {
 app.get("/manual-dispatch", async function (req, res) {
   if(req.query.subject) {
     console.log(`Only one subject to (re-)dispatch: ${req.query.subject}`);
-    processSubjectsQueue.addJob(async () => await processSubject(req.query.subject));
+    distributeAndSchedule(
+      healingQueuePool,
+      async () => await processSubject(req.query.subject)
+    );
   }
   else {
     console.log(`Dispatching all submissions (again) from GRAPH ${DISPATCH_SOURCE_GRAPH}`);
@@ -106,7 +121,10 @@ app.get("/manual-dispatch", async function (req, res) {
     console.log(`Found ${submissions.length} submissions to (re-)dispatch.`);
     console.log(`This might take a while; big amount can take big time`);
     for(const submission of submissions) {
-      processSubjectsQueue.addJob(async () => await processSubject(submission));
+      distributeAndSchedule(
+        healingQueuePool,
+        async () => await processSubject(submission)
+      );
     }
   }
   console.log(`Scheduling done`);
@@ -142,7 +160,10 @@ app.get("/heal-submission", async function (req, res) {
 
   if(req.query.subject) {
     console.log(`Only one submission to (re-)dispatch: ${req.query.subject}`);
-    processSubjectsQueue.addJob(async () => await healSubmission(req.query.subject));
+    distributeAndSchedule(
+      healingQueuePool,
+      async () => await healSubmission(req.query.subject)
+    );
     console.log(`Scheduling done`);
     return res.status(201).send();
   }
@@ -162,7 +183,10 @@ app.get("/heal-submission", async function (req, res) {
   }
 
   for(const submission of submissions) {
-    processSubjectsQueue.addJob(async () => await healSubmission(submission));
+    distributeAndSchedule(
+      healingQueuePool,
+      async () => await healSubmission(submission)
+    );
   }
 
   return res.status(201).send();

--- a/config.js
+++ b/config.js
@@ -3,4 +3,4 @@ export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankEre
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
-export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1 );
+export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1);

--- a/config.js
+++ b/config.js
@@ -3,4 +3,4 @@ export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankEre
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
-export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1);
+export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES) || 1;

--- a/config.js
+++ b/config.js
@@ -3,3 +3,4 @@ export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankEre
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
+export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES || 1 );

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -39,3 +39,14 @@ export class ProcessingQueue {
     });
   }
 }
+export async function distributeAndSchedule(queuePool, job) {
+  const smallestQueue = queuePool.reduce(
+    (smallestQueueSoFar, currentQueue) => {
+      if(currentQueue.length < smallestQueueSoFar.length) {
+        return currentQueue;
+      }
+      return smallestQueueSoFar;
+    }, queuePool[0]);
+
+  smallestQueue.addJob(job);
+}

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -6,6 +6,10 @@ export class ProcessingQueue {
     this.executing = false; //To avoid subtle race conditions TODO: is this required?
   }
 
+  get length() {
+    return this.queue.length;
+  }
+
   async run() {
     if (this.queue.length > 0 && !this.executing) {
       const job = this.queue.shift();

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -40,6 +40,11 @@ export class ProcessingQueue {
   }
 }
 
+/**
+ * Distributes and schedules a job among a pool of queues, selecting the queue with the fewest tasks.
+ * @param {ProcessingQueue[]} queuePool - The pool of ProcessingQueue instances to choose from.
+ * @param {Function} job - The job to be added to the smallest queue.
+ */
 export async function distributeAndSchedule(queuePool, job) {
   const smallestQueue = queuePool.reduce(
     (smallestQueueSoFar, currentQueue) => {

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -39,6 +39,7 @@ export class ProcessingQueue {
     });
   }
 }
+
 export async function distributeAndSchedule(queuePool, job) {
   const smallestQueue = queuePool.reduce(
     (smallestQueueSoFar, currentQueue) => {


### PR DESCRIPTION
To speed up the healing, multiple queues for healing have been introduced. 

To see it in action
```
submissions-dispatcher:
  image: lblod/worship-submissions-graph-dispatcher-service:0.13.0.rc-parallel-queues-1
  environment:
    NUMBER_OF_HEALING_QUEUES: 10
```

Once up and running:
```
drc exec submissions-dispatcher wget http://localhost/heal-submission
```

Also; the 'normal-operations' were split in a separate queue, so healing doesn't block normal operations.