### PR TITLE
Adjusting dispatch for inactive Centrale Bestuuren in Meerjarenplan(aanpasing) / Budget(wijziging) / Jaarrekening submissions made by EB's

### DIFF
--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -11,25 +11,28 @@ const rules = [];
 **/
 let rule = {
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b', // Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan - EB met CB 
-  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB
+  matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB (Active)
   destinationInfoQuery: ( sender ) => {
     return `
         PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
             ?bestuurseenheid org:hasSubOrganization ?sender;
               besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+              regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
               skos:prefLabel ?label;
               mu:uuid ?uuid.
 
             FILTER EXISTS {
               ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
             }
           } UNION {
             VALUES ?bestuurseenheid {
@@ -41,7 +44,8 @@ let rule = {
 
             FILTER EXISTS {
               ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
             }
           }
         }
@@ -116,6 +120,7 @@ rule = {
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+        PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -123,7 +128,8 @@ rule = {
             ${toezichthoudendeQuerySnippet()}
             FILTER NOT EXISTS {
               ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           } UNION {
             VALUES ?bestuurseenheid {
@@ -136,7 +142,8 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           }
         }
@@ -242,6 +249,7 @@ rule = {
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
       PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
       PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+      PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -253,7 +261,8 @@ rule = {
 
           FILTER NOT EXISTS {
             ?centraalBestuur org:hasSubOrganization ?sender ;
-              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> ;
+              regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
           }
         } UNION {
           VALUES ?bestuurseenheid {
@@ -266,7 +275,8 @@ rule = {
 
           FILTER NOT EXISTS {
             ?centraalBestuur org:hasSubOrganization ?sender ;
-              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> .
+              besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> ;
+              regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
           }
         }
       }
@@ -282,7 +292,7 @@ rules.push(rule);
 * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> CKB Deinze
 */
 rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget EB with CB
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget EB with CB (Active)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {
     return `
@@ -291,6 +301,7 @@ rule = {
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
       PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
       PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+      PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -299,6 +310,7 @@ rule = {
             besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
             mu:uuid ?uuid ;
             skos:prefLabel ?label ;
+            regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
             a ere:CentraalBestuurVanDeEredienst  .
         } UNION {
           VALUES ?bestuurseenheid {

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -71,6 +71,7 @@ rule = {
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
         PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+        PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -82,7 +83,8 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           } UNION {
             VALUES ?bestuurseenheid {
@@ -95,7 +97,8 @@ rule = {
 
             FILTER NOT EXISTS {
               ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           }
         }

--- a/dispatch-rules/jaarrekening.js
+++ b/dispatch-rules/jaarrekening.js
@@ -1,5 +1,5 @@
 import { sparqlEscapeUri } from "mu";
-import { toezichthoudendeQuerySnippet, repOrgQuerySnippet } from './query-snippets';
+import { toezichthoudendeQuerySnippet } from './query-snippets';
 
 const rules = [];
 
@@ -10,19 +10,21 @@ const rules = [];
 * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> CKB Deinze
 **/
 let rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB met CB
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB met CB (Active)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB
   destinationInfoQuery: ( sender ) => {
     return `
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX org: <http://www.w3.org/ns/org#>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         {
           ?bestuurseenheid org:hasSubOrganization ?sender;
             <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+            regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
             mu:uuid ?uuid;
             skos:prefLabel ?label.
         } UNION {
@@ -34,7 +36,8 @@ let rule = {
 
           ?centraalBestuur org:hasSubOrganization ?bestuurseenheid;
             <http://data.vlaanderen.be/ns/besluit#classificatie>
-              <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+              <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+            regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
         }
       }
     `;
@@ -50,13 +53,14 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
-  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB zonder CB
+  documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB zonder CB 
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB
   destinationInfoQuery: ( sender ) => {
     return `
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX org: <http://www.w3.org/ns/org#>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -65,7 +69,9 @@ rule = {
           FILTER NOT EXISTS {
             ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
               <http://data.vlaanderen.be/ns/besluit#classificatie>
-                <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+              regorg:orgStatus
+                <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
           }
         } UNION {
             VALUES ?bestuurseenheid {
@@ -77,7 +83,9 @@ rule = {
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus
+                  <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
         } UNION {
             VALUES ?bestuurseenheid {
@@ -88,7 +96,9 @@ rule = {
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?bestuurseenheid;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus
+                  <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
         }
       }

--- a/dispatch-rules/meerjarenplanwijziging.js
+++ b/dispatch-rules/meerjarenplanwijziging.js
@@ -1,5 +1,5 @@
 import { sparqlEscapeUri } from "mu";
-import { toezichthoudendeQuerySnippet, repOrgQuerySnippet } from './query-snippets';
+import { toezichthoudendeQuerySnippet } from './query-snippets';
 
 const rules = [];
 
@@ -12,12 +12,13 @@ const rules = [];
 let rule = {
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f', // Meerjarenplan(wijziging)
   matchSentByEenheidClass: eenheidClass =>
-    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB
+    eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB (Active)
   destinationInfoQuery: ( sender ) => {
     return `
         PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -25,13 +26,15 @@ let rule = {
             ?bestuurseenheid org:hasSubOrganization ?sender;
             <http://data.vlaanderen.be/ns/besluit#classificatie>
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+              regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
               skos:prefLabel ?label;
               mu:uuid ?uuid.
 
             FILTER EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> ;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
             }
           } UNION {
             VALUES ?bestuurseenheid {
@@ -44,7 +47,8 @@ let rule = {
             FILTER EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054> ;
+                  regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
             }
           }
         }
@@ -69,6 +73,7 @@ rule = {
         PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+        PREFIX regorg: <http://www.w3.org/ns/regorg#>
 
         SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
@@ -77,7 +82,8 @@ rule = {
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           } UNION {
             ?bestuurseenheid org:linkedTo ?sender ;
@@ -88,7 +94,8 @@ rule = {
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           } UNION {
             VALUES ?bestuurseenheid {
@@ -102,7 +109,8 @@ rule = {
             FILTER NOT EXISTS {
               ?cb <http://www.w3.org/ns/org#hasSubOrganization> ?sender;
                 <http://data.vlaanderen.be/ns/besluit#classificatie>
-                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>.
+                  <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worship-submissions-graph-dispatcher-service",
-  "version": "0.14.0",
+  "version": "0.15.0-rc.1",
   "description": "Microservice moves meb:Submissions to correct org graph.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

DL-5707

This PR adjusts rules for Meerjarenplan(aanpasing) / Budget(wijziging) / Jaarrekening submissions targeted to CB (Centrale Bestuur) when made by EB (Bestuur van de Eredienst). It's possible that over time Centrale bestuur goes inactive thus, submissions wont be consulted.

These rules adjustments are then made to "verify" if the CB is still active with the predicate `regorg:orgStatus` :

- <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> Goes for "Niet actief"
- <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> Goes for "Actief"

Inactive CB will be treated as not attached to the EB, so it will be handled by the rule "EB has no CB".

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

:warning: I suggest to make a backup if you tweak the status of the CB

1. Setup consumer/producer stack (Loket/Worship-decisions-database) + add the RC image of this service in docker-compose.override
2. Create submissions Jaarrening / Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan & Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie / Meerjarenplan(aanpassing) with a Bestuur van de Eredienst with an active/inactive Centrale Bestuur and without a Centrale Bestuur
3. Inactive ones should be considered as without a Eredienst Bestuur where active should flow like before except the dispatcher rule will now check if the Centrale Bestuur is active.

#### Here's some useful information :

- https://data.lblod.info/id/besturenVanDeEredienst/6fdd5f4db430e5bc42d4e1fb130d6eb2 -> EB without CB
- You can check the Centrale Bestuur status with `regorg:orgStatus`
	- <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> Niet actief
	- <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> actief

E.g if you are looking for an active one : 

```sparql
 PREFIX regorg: <http://www.w3.org/ns/regorg#>
 PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>

 SELECT DISTINCT ?centraleBestuur ?status ?eredienstBestuur WHERE {
	   BIND(<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?status)
     ?centraleBestuur a ere:CentraalBestuurVanDeEredienst ;
                        regorg:orgStatus ?status;
                        org:hasSubOrganization ?eredienstBestuur .
        } LIMIT 10
```

You can play around to find the rules if you need. Once submissions are ingested you can change the status of the CB

```sparql
PREFIX regorg: <http://www.w3.org/ns/regorg#>
INSERT {
GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
<http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> regorg:orgStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>
}
}

DELETE {
GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
<http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>
}
}

WHERE {
GRAPH <http://mu.semte.ch/graphs/landing-zone/op-public> {
<http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>
}
}
```

Then run the healing from the day of creation of your submissions e.g : 
`docker-compose exec submissions-dispatcher wget http://localhost/heal-submission?sentDateSince=2024-03-01`

Note that there is many edge cases like EB has no CB, then it's linked to the RO but in some cases there is no RO, so the GO or PO should be the ones that receive the submissions once dispatched

#### Test case 

##### Dispatched to CKB Diest as Actief 
![Screenshot 2024-03-12 at 17-13-46 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/2a25c507-da7e-4edc-8aee-38c0bba5a5fc)


##### Healed after making CKB Diest as Niet actief
![Screenshot 2024-03-12 at 17-31-33 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/b44919e5-2663-4b4f-9d27-30d42d8f8ea1)

Re-dispatched 
Jaarrekening case -> Sender / GO or PO / PG (ABB)
Budget(wijziging) -> Sender / PG (ABB) / RO if there is a RO, if not, to the GO or PO
Meerjarenplan(aanpasing) -> Sender / PG (ABB) / RO (assuming there is a RO) / GO or PO

![Screenshot 2024-03-12 at 17-37-10 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/2a9c4712-67c6-43df-9897-f5cdb9c3316b)

![Screenshot 2024-03-12 at 18-36-45 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/5bd3e5f3-3137-4d7d-ad67-c5b159e242a9)

![Screenshot 2024-03-12 at 18-37-08 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/f799d3a3-c663-4cb2-943e-e980d23cce0c)

![Screenshot 2024-03-12 at 18-37-38 Erediensten Toezichtsdatabank](https://github.com/lblod/worship-submissions-graph-dispatcher-service/assets/38471754/de8a66a6-e95b-4e97-942d-4ec873618d68)

 
# What to check

- N/A

# Links to other PR's

- N/A

# Notes

Release + Bump on worship decisions database