### PR TITLE
Feature/deal with cross referenced data

### DIFF
--- a/dispatch-rules/advies-jaarrekening.js
+++ b/dispatch-rules/advies-jaarrekening.js
@@ -16,19 +16,34 @@ let rule = {
       'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001' ]
       .indexOf(eenheidClass) > -1 ;
   },
-  destinationInfoQuery: ( sender ) => {
+  destinationInfoQuery: ( sender, submission ) => {
     return `
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX org: <http://www.w3.org/ns/org#>
       PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+      PREFIX eli: <http://data.europa.eu/eli/ontology#>
+      PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+      PREFIX prov: <http://www.w3.org/ns/prov#>
 
       SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
+        BIND(${sparqlEscapeUri(submission)} as ?submission)
+
         {
           VALUES ?bestuurseenheid {
             <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
             ${sparqlEscapeUri(sender)}
           }
+          ?bestuurseenheid mu:uuid ?uuid;
+            skos:prefLabel ?label.
+        }
+        UNION {
+          ?submission a meb:Submission;
+            prov:generated ?formData.
+
+          ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+            eli:is_about ?bestuurseenheid.
+
           ?bestuurseenheid mu:uuid ?uuid;
             skos:prefLabel ?label.
         }

--- a/export-config.js
+++ b/export-config.js
@@ -115,4 +115,11 @@ export default [
    type: `http://rdf.myexperiment.org/ontologies/base/Submission`,
    pathToSubmission: `?submission a <http://rdf.myexperiment.org/ontologies/base/Submission> .\n FILTER(?submission = ?subject)`
   },
+  {
+   type: `http://data.vlaanderen.be/ns/besluit#Artikel`,
+   pathToSubmission: `?subject a <http://data.vlaanderen.be/ns/besluit#Artikel>.
+                      ?submissionDocument <http://data.europa.eu/eli/ontology#has_part> ?subject.
+                      ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+                         <http://purl.org/dc/terms/subject> ?submissionDocument.`
+  },
 ];


### PR DESCRIPTION
This  tackles DL-5872.
- Submission dispatcher is going to take `besluit:Artikel` into account
- Advies jaarrekening needed update, as `eli:is_about` wasn't taken into account.

Besides the usual code review, I would suggest waiting on [DL-5866] before testing this, since testing this in an isolated manner is rather complicated to set up and very long to explain.

To test (after you have the frontend)

- First login as Kerkfabriek St.-Ambrosius van Dilbeek , make a jaarrekening. Press send.
- Login as 'gemeente dilbeek'
  - Make Advies Jaarrekening eredienstbesturen and select the document from Kerkfabriek St.-Ambrosius van Dilbeek.
   -  Press send.
   - 
Wait for the sync to happen. 
Login as "Kerkfabriek St.-Ambrosius van Dilbeek" on worship-submissions.

Eventually the document should appear

Meanwhile, I release 0.16.0-rc.1 so it can be included in https://github.com/lblod/app-worship-decisions-database/pull/80
