### PR TITLE
Fixing `Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie - EB zonder CB` query

### DIFF
--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -129,11 +129,6 @@ rule = {
           BIND(${sparqlEscapeUri(sender)} as ?sender)
           {
             ${toezichthoudendeQuerySnippet()}
-            FILTER NOT EXISTS {
-              ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
-                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
-            }
           } UNION {
             VALUES ?bestuurseenheid {
               <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -137,12 +137,6 @@ rule = {
 
             ?bestuurseenheid skos:prefLabel ?label;
               mu:uuid ?uuid.
-
-            FILTER NOT EXISTS {
-              ?cb org:hasSubOrganization ?sender;
-                besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
-                regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
-            }
           }
         }
     `;


### PR DESCRIPTION
# Description

DL-5707 related to DL-5997

This PR removes filter where it causes the query to fail.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Setup consumer/producer stack (Loket/Worship-decisions-database) + add the image of this service in docker-compose.override
2. Create submission Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie /with a Bestuur van de Eredienst with an active Centrale Bestuur E.g H. Hart van Aalst
3. Inactive ones should be considered as without a Eredienst Bestuur where active should flow like before except the dispatcher rule will now check if the Centrale Bestuur is active.
 
# What to check

- N/A

# Links to other PR's

- N/A

# Notes

Release + Bump on worship decisions database