### PR TITLE
Improve healing and dispatching

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ import {
   getSubmissionForSubject,
   getSubmissionInfo,
   getDestinators,
+  removeSubjectFromGraph,
   copySubjectDataToGraph,
   getRelatedSubjectsForSubmission,
   getSubmissions,
@@ -266,6 +267,20 @@ async function dispatch(submission) {
 
       // List of subjects and the graph they are in
       const subjectsAndGraphs = await getGraphsAndCountForSubjects(relatedSubjects);
+
+      // Find subjects that no longer have a correct destinator by calculating a difference
+      const removeSubjectsPerGraph = [];
+      for (const currSub of subjectsAndGraphs) {
+        const found = allSubjectsAndGraphs.find((e) =>
+          e.subject === currSub.subject &&
+          e.graph === currSub.graph);
+        if (!found)
+          removeSubjectsPerGraph.push(currSub);
+      }
+
+      for (const { subject, graph } of removeSubjectsPerGraph) {
+        await removeSubjectFromGraph(subject, graph);
+      }
 
       // Difference between the two lists, only ones remaining are the missing or incorrect ones
       const missingSubjectsPerGraph = [];

--- a/app.js
+++ b/app.js
@@ -158,7 +158,6 @@ app.get("/heal-submission", async function (req, res) {
     console.log(`Only one submission to (re-)dispatch: ${req.query.subject}`);
     distributeAndSchedule(
       healingQueuePool,
-      //async () => await healSubmission(req.query.subject)
       async () => await processSubject(req.query.subject)
     );
     console.log(`Scheduling done`);
@@ -182,7 +181,6 @@ app.get("/heal-submission", async function (req, res) {
   for(const submission of submissions) {
     distributeAndSchedule(
       healingQueuePool,
-      //async () => await healSubmission(submission)
       async () => await processSubject(submission)
     );
   }

--- a/app.js
+++ b/app.js
@@ -9,12 +9,10 @@ import {
   getSubmissionForSubject,
   getSubmissionInfo,
   getDestinators,
-  //copySubjectDataToDestinators,
   copySubjectDataToGraph,
   getRelatedSubjectsForSubmission,
   getSubmissions,
   getGraphsAndCountForSubjects,
-  //removeSubjects
 } from "./util/queries";
 import dispatchRules from "./dispatch-rules/entrypoint";
 import exportConfig from "./export-config";
@@ -46,7 +44,6 @@ if(ENABLE_HEALING) {
     for(const submission of submissions) {
       distributeAndSchedule(
         healingQueuePool,
-        //async () => await healSubmission(submission)
         async () => await processSubject(submission)
       );
     }
@@ -285,30 +282,3 @@ async function dispatch(submission) {
     }
   }
 }
-
-/*
- * Removes a submission from its target graphs.
- * Re-dispatch the submission again.
- * Use-case: handle data updates (e.g. bestuurseenheid changes) which affect the dispatch-rules
- */
-//async function healSubmission( submission ) {
-//  try {
-//    let relatedSubjects = [];
-//    for (const config of exportConfig) {
-//      const subjects = await getRelatedSubjectsForSubmission(
-//        submission,
-//        config.type,
-//        config.pathToSubmission
-//      );
-//      relatedSubjects = [ ...relatedSubjects, ...subjects ];
-//    }
-//    await removeSubjects([submission, ...relatedSubjects],
-//                         ORG_GRAPH_BASE + '/.*/' + ORG_GRAPH_SUFFIX);
-//    await processSubject(submission);
-//  } catch (e) {
-//    console.error(`Error while processing a subject: ${e.message ? e.message : e}`);
-//    await sendErrorAlert({
-//      message: `Something unexpected went wrong while processing a subject ${submission}: ${e.message ? e.message : e}`
-//    });
-//  }
-//}

--- a/app.js
+++ b/app.js
@@ -260,6 +260,7 @@ async function dispatch(submission) {
         });
         return acc;
       }, []);
+
       //Count number of triples per subject
       const counts = await getGraphsAndCountForSubjects(relatedSubjects, [DISPATCH_SOURCE_GRAPH, DISPATCH_FILES_GRAPH]);
       allSubjectsAndGraphs.forEach((e) => {

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 export const ORG_GRAPH_BASE = process.env.ORG_GRAPH_BASE || 'http://mu.semte.ch/graphs/organizations';
 export const ORG_GRAPH_SUFFIX = process.env.ORG_GRAPH_SUFFIX || 'ABB_databankErediensten_LB_CompEnts_gebruiker';
 export const DISPATCH_SOURCE_GRAPH = process.env.DISPATCH_SOURCE_GRAPH || 'http://mu.semte.ch/graphs/temp/for-dispatch';
+export const DISPATCH_FILES_GRAPH = process.env.DISPATCH_FILES_GRAPH || 'http://mu.semte.ch/graphs/temp/original-physical-files-data';
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
 export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES) || 1;

--- a/dispatch-rules/advies-budgetwijziging.js
+++ b/dispatch-rules/advies-budgetwijziging.js
@@ -32,11 +32,11 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a meb:Submission;
+        ?submission
           pav:createdBy ?sender;
           prov:generated ?formData.
 
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+        ?formData
           eli:is_about ?aboutEenheid.      
 
         OPTIONAL {

--- a/dispatch-rules/advies-meerjarenplanwijziging.js
+++ b/dispatch-rules/advies-meerjarenplanwijziging.js
@@ -22,11 +22,11 @@ let rule = {
         BIND(${sparqlEscapeUri(submission)} as ?submission)
        {
 
-         ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+         ?submission
            <http://purl.org/pav/createdBy> ?sender;
            <http://www.w3.org/ns/prov#generated> ?formData.
 
-         ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+         ?formData
            <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
 
          VALUES ?worshipType {

--- a/dispatch-rules/besluit-budgetwijziging.js
+++ b/dispatch-rules/besluit-budgetwijziging.js
@@ -38,11 +38,11 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+        ?submission
           <http://purl.org/pav/createdBy> ?sender;
           <http://www.w3.org/ns/prov#generated> ?formData.
 
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+        ?formData
           <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
 
         VALUES ?worshipType {

--- a/dispatch-rules/besluit-meerjarenplanwijziging.js
+++ b/dispatch-rules/besluit-meerjarenplanwijziging.js
@@ -38,11 +38,11 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+        ?submission
           <http://purl.org/pav/createdBy> ?sender;
           <http://www.w3.org/ns/prov#generated> ?formData.
 
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+        ?formData
           <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
 
         VALUES ?worshipType {

--- a/dispatch-rules/erekenning-reguliere-procedure.js
+++ b/dispatch-rules/erekenning-reguliere-procedure.js
@@ -26,11 +26,9 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a meb:Submission;
+        ?submission
           pav:createdBy ?sender;
           prov:generated ?formData.
-
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
 
         VALUES ?bestuurseenheid {
           <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>

--- a/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
+++ b/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
@@ -51,11 +51,11 @@ let rule = {
             BIND(${sparqlEscapeUri(sender)} as ?sender)
             BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-            ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+            ?submission
               <http://purl.org/pav/createdBy> ?sender;
               <http://www.w3.org/ns/prov#generated> ?formData.
 
-            ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+            ?formData
               <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
 
             VALUES ?worshipType {

--- a/dispatch-rules/naamswijziging.js
+++ b/dispatch-rules/naamswijziging.js
@@ -26,11 +26,9 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a meb:Submission;
+        ?submission
           pav:createdBy ?sender;
           prov:generated ?formData.
-
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
 
         VALUES ?bestuurseenheid {
           <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>

--- a/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
+++ b/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
@@ -26,11 +26,9 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a meb:Submission;
+        ?submission
           pav:createdBy ?sender;
           prov:generated ?formData.
-
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
 
         VALUES ?bestuurseenheid {
           <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>

--- a/dispatch-rules/opvragen-bijkomende-inlichtingen-eredienstbesturen.js
+++ b/dispatch-rules/opvragen-bijkomende-inlichtingen-eredienstbesturen.js
@@ -33,11 +33,11 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+        ?submission
           <http://purl.org/pav/createdBy> ?sender;
           <http://www.w3.org/ns/prov#generated> ?formData.
 
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+        ?formData
           <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
 
         VALUES ?worshipType {

--- a/dispatch-rules/samenvoeging.js
+++ b/dispatch-rules/samenvoeging.js
@@ -26,11 +26,9 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a meb:Submission;
+        ?submission
           pav:createdBy ?sender;
           prov:generated ?formData.
-
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
 
         VALUES ?bestuurseenheid {
           <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>

--- a/dispatch-rules/schorsingsbesluit.js
+++ b/dispatch-rules/schorsingsbesluit.js
@@ -38,11 +38,11 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+        ?submission
           <http://purl.org/pav/createdBy> ?sender;
           <http://www.w3.org/ns/prov#generated> ?formData.
 
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>;
+        ?formData
           <http://data.europa.eu/eli/ontology#is_about> ?aboutEenheid.
 
         VALUES ?worshipType {

--- a/dispatch-rules/wijziging-gebiedsomschrijving.js
+++ b/dispatch-rules/wijziging-gebiedsomschrijving.js
@@ -26,11 +26,9 @@ let rule = {
         BIND(${sparqlEscapeUri(sender)} as ?sender)
         BIND(${sparqlEscapeUri(submission)} as ?submission)
 
-        ?submission a meb:Submission;
+        ?submission
           pav:createdBy ?sender;
           prov:generated ?formData.
-
-        ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
 
         VALUES ?bestuurseenheid {
           <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>

--- a/export-config.js
+++ b/export-config.js
@@ -77,42 +77,33 @@ export default [
     type: `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject`,
     pathToSubmission: `?subject <http://purl.org/dc/terms/type> <http://data.lblod.gift/concepts/form-file-type>.
                        ?s <http://purl.org/dc/terms/source> ?subject.
-                       ?s a <http://mu.semte.ch/vocabularies/ext/SubmissionDocument>.
-                       ?submission <http://purl.org/dc/terms/subject> ?s.
-                       ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>.`
+                       ?submission <http://purl.org/dc/terms/subject> ?s.`
   },
   {
     type: `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject`,
     pathToSubmission: `?formData <http://purl.org/dc/terms/hasPart> ?subject.
-                       ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
-                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.
-                       ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>.`
+                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.`
   },
   {
     type: `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject`,
     pathToSubmission: `?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?virtualFile .
                        ?formData <http://purl.org/dc/terms/hasPart> ?virtualFile.
-                       ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
-                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.
-                       ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>.`
+                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.`
   },
   {
     type: `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#RemoteDataObject`,
     pathToSubmission: `?formData <http://purl.org/dc/terms/hasPart> ?subject.
-                       ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
-                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.
-                       ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>.`
+                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.`
   },
   {
     type: `http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#LocalFileDataObject`,
     pathToSubmission: `?subject <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#dataSource> ?vfile.
                        ?formData <http://purl.org/dc/terms/hasPart> ?vfile.
-                       ?formData a <http://lblod.data.gift/vocabularies/automatische-melding/FormData>.
-                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.
-                       ?submission a <http://rdf.myexperiment.org/ontologies/base/Submission>.`
+                       ?submission <http://www.w3.org/ns/prov#generated> ?formData.`
   },
   {
-   type: `http://rdf.myexperiment.org/ontologies/base/Submission`,
-   pathToSubmission: `?submission a <http://rdf.myexperiment.org/ontologies/base/Submission> .\n FILTER(?submission = ?subject)`
+    type: `http://rdf.myexperiment.org/ontologies/base/Submission`,
+    pathToSubmission: `?submission a <http://rdf.myexperiment.org/ontologies/base/Submission> .
+                       FILTER(?submission = ?subject)`
   },
 ];

--- a/lib/processing-queue.js
+++ b/lib/processing-queue.js
@@ -2,8 +2,8 @@ export class ProcessingQueue {
   constructor(name = 'Default') {
     this.name = name;
     this.queue = [];
-    this.run();
     this.executing = false; //To avoid subtle race conditions TODO: is this required?
+    this.run();
   }
 
   get length() {

--- a/util/queries.js
+++ b/util/queries.js
@@ -10,12 +10,8 @@ export async function getRelatedSubjectsForSubmission(submission, subjectType, p
   const queryStr = `
     SELECT DISTINCT ?subject WHERE {
       BIND(${sparqlEscapeUri(submission)} as ?submission)
-      GRAPH ?g {
-        ?subject a ${sparqlEscapeUri(subjectType)}.
-      }
       ${pathToSubmission}
-    }
-  `;
+    }`;
 
   const result = await query(queryStr);
   return result.results.bindings.map(r => r.subject.value);

--- a/util/queries.js
+++ b/util/queries.js
@@ -2,7 +2,7 @@ import {  sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime, sparqlEscap
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
 import exportConfig from "../export-config";
 import { parseResult } from './utils';
-import { ORG_GRAPH_BASE, ORG_GRAPH_SUFFIX, DISPATCH_SOURCE_GRAPH } from '../config';
+import { ORG_GRAPH_BASE, ORG_GRAPH_SUFFIX, DISPATCH_SOURCE_GRAPH, DISPATCH_FILES_GRAPH } from '../config';
 
 const CREATOR = 'http://lblod.data.gift/services/worship-submissions-graph-dispatcher-service';
 
@@ -131,8 +131,12 @@ export async function copySubjectDataToGraph(subject, graph) {
         }
      }
      WHERE {
+        VALUES ?g {
+          ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)}
+          ${sparqlEscapeUri(DISPATCH_FILES_GRAPH)}
+        }
         BIND(${sparqlEscapeUri(subject)} as ?s)
-        GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
+        GRAPH ?g {
           ?s ?p ?o.
         }
      }

--- a/util/queries.js
+++ b/util/queries.js
@@ -99,8 +99,22 @@ export async function getGraphsAndCountForSubjects(subjects, graphs) {
   return parseResult(await query(q));
 }
 
-export async function copySubjectDataToGraph(subject, graph) {
+export async function copySubjectDataToGraph(subject, graph, toRemoveFirst = false) {
+  const removeQueryStr = toRemoveFirst ? `
+    DELETE {
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ?subject ?p ?o .
+      }
+    }
+    WHERE {
+      BIND (${sparqlEscapeUri(subject)} as ?subject)
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ?subject ?p ?o .
+      }
+    }
+  ` : '';
   const queryStr = `
+     ${toRemoveFirst ? removeQueryStr + '\n;\n' : ''}
      INSERT {
         GRAPH ${sparqlEscapeUri(graph)} {
           ?s ?p ?o.

--- a/util/queries.js
+++ b/util/queries.js
@@ -103,26 +103,6 @@ export async function getGraphsAndCountForSubjects(subjects, graphs) {
   return parseResult(await query(q));
 }
 
-//export async function copySubjectDataToDestinators(subject, destinators) {
-//  for(const destinator of destinators) {
-//    const targetGraph = ORG_GRAPH_BASE + '/' + destinator.uuid + '/' + ORG_GRAPH_SUFFIX;
-//    const queryStr = `
-//       INSERT {
-//          GRAPH ${sparqlEscapeUri(targetGraph)} {
-//            ?s ?p ?o.
-//          }
-//       }
-//       WHERE {
-//          BIND(${sparqlEscapeUri(subject)} as ?s)
-//          GRAPH ${sparqlEscapeUri(DISPATCH_SOURCE_GRAPH)} {
-//            ?s ?p ?o.
-//          }
-//       }
-//    `;
-//    await update(queryStr);
-//  }
-//}
-
 export async function copySubjectDataToGraph(subject, graph) {
   const queryStr = `
      INSERT {
@@ -200,27 +180,3 @@ export async function getSubmissions( { inGraph, sentDateSince } = {}) {
   const result = await query(queryStr);
   return parseResult(result).map(s => s.submission);
 }
-
-//export async function removeSubjects(subjects, graphFilterRegex = '') {
-//  const filter = graphFilterRegex ?
-//        `FILTER( regex(str(?graph), ${sparqlEscapeString(graphFilterRegex)} ) )`
-//        : '';
-//
-//  const queryStr = `
-//    DELETE {
-//      GRAPH ?graph {
-//        ?s ?p ?o
-//      }
-//    }
-//    WHERE {
-//      VALUES ?s {
-//        ${subjects.map(sparqlEscapeUri).join('\n')}
-//      }
-//      GRAPH ?graph {
-//       ?s ?p ?o
-//     }
-//     ${filter}
-//    }
-//  `;
-//  await query(queryStr);
-//}

--- a/util/queries.js
+++ b/util/queries.js
@@ -99,6 +99,23 @@ export async function getGraphsAndCountForSubjects(subjects, graphs) {
   return parseResult(await query(q));
 }
 
+export async function removeSubjectFromGraph(subject, graph) {
+  const removeQueryStr = `
+    DELETE {
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ?subject ?p ?o .
+      }
+    }
+    WHERE {
+      BIND (${sparqlEscapeUri(subject)} as ?subject)
+      GRAPH ${sparqlEscapeUri(graph)} {
+        ?subject ?p ?o .
+      }
+    }
+  `;
+  await update(removeQueryStr);
+}
+
 export async function copySubjectDataToGraph(subject, graph, toRemoveFirst = false) {
   const removeQueryStr = toRemoveFirst ? `
     DELETE {


### PR DESCRIPTION
**[DL-5895] More efficient healing**

Healing takes too much time and performs too many deletes and inserts. These can be reduced by checking certain criteria to decide whether changes are needed. How it works now:

1. Collect all the submissions in the "for-dispatch" graph.
2. Find all related subjects (SubmissionDocument, FormData, attachments, ...)
3. Calculate for each subject the graphs in which they *should* come and query for the amount of triples per subject.
4. Query for where the subjects currently are and how many triples they have.
5. Calculate the difference between the current dispatched submissions to filter out the graphs where the submissions are no longer needed.
6. Remove those subjects from those graphs.
7. Calculate the difference between the current dispatched submissions to see what subject is missing from what graph and if there are missing triples.
8. Perform copies for that difference list only.
   - If the amount of triples is lower than what was already in the org graph: remove the subject and copy
   - If the amount of triples is higher than what was already in the org graph: copy

Some notes:

* Healing and processing a submission were so similar that I merged the code.
* It also heals the triples for physical files (`<share://...>`) now. This was not there before. This service used to attempt to heal triples for all the subjects but would never find the triples because they are in a different graph (the graph for the `files-consumer`). I think this will come in handy when dispatching rules change and subjects need to be copied to another graph as well. The `file-consumer` does not have healing or a mechanism to do that on its own(?).
* The main improvement for this PR is that it no longer removes all the data for the submission, before inserting the same things again. Instead it tries to figure out the difference between calculated destinators and the current graphs the data can be found, and the number of triples per subject. This causes less deletions and insertions in the database, while still maintaining correct updates to the data.
* A lot of speed-up can be achieved by making the SPARQL queries simpler. Some queries can be sped up from 15s to 0.1s on my local machine. The downside is that they might be less accurate. E.g. I removed type checking in a lot of queries. Shouldn't make a difference because the predicates are unique enough such that subjects can only be linked together in a certain way. In other cases, type checking was fully redundant, but could still speed up queries when removed. Check out this commit for all these query-related changes: https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/25/commits/7155a8e169e48852207595663395b8b1bcd9c113