### PR TITLE
Workaround for inconsistencies files data

### DIFF
--- a/app.js
+++ b/app.js
@@ -257,7 +257,7 @@ async function dispatch(submission) {
         return acc;
       }, []);
 
-      //Count number of triples per subject
+      // Count number of triples per subject
       let counts = await getGraphsAndCountForSubjects(relatedSubjects, [DISPATCH_SOURCE_GRAPH, DISPATCH_FILES_GRAPH]);
       // Deduplicate the counts
       // In certain scenario's, the physical file triples are not completely

--- a/util/queries.js
+++ b/util/queries.js
@@ -78,7 +78,7 @@ export async function getDestinators(submissionInfo, rule) {
 }
 
 export async function getGraphsAndCountForSubjects(subjects, graphs) {
-  const bindGraph = graphs?.length ? `VALUES ?graph { ${graphs.map(sparqlEscapeUri).join('\n')} }` : '';
+  const bindGraph = graphs?.length ? `VALUES ?graph {\n${graphs.map(sparqlEscapeUri).join('\n')}\n}` : '';
   const graphFilter = graphs?.length ? '' : `FILTER (REGEX(STR(?graph), "${ORG_GRAPH_BASE}"))`;
   const q = `
     SELECT DISTINCT

--- a/util/queries.js
+++ b/util/queries.js
@@ -82,8 +82,8 @@ export async function getGraphsAndCountForSubjects(subjects, graphs) {
   const graphFilter = graphs?.length ? '' : `FILTER (REGEX(STR(?graph), "${ORG_GRAPH_BASE}"))`;
   const q = `
     SELECT DISTINCT
+        ?graph
         ?subject
-        ${graphs?.length ? '' : '?graph'}
         (COUNT(?p) as ?count) {
       VALUES ?subject {
         ${subjects.map(sparqlEscapeUri).join('\n')}


### PR DESCRIPTION
**Related to [DL5895]**

In certain scenario's it is possible that not all triples for the physical file are in both the `temp/for-dispatch` and the `temp/original-physical-files-data` graphs. This would cause there to be multiple entries in the counts array with different numbers. When filtering for subjects that need to be copied, only the first entry is looked at. If that number is from the graph where a triple was missing, then the subject would **always** (on every healing) be selected for a SPARQL DELETE and INSERT. By deduplicating the counts array based on taking the maximum of the triples that exist, we can reduce the amount of DELETEs and INSERTs even further.