### PR TITLE
Fix: use all rules at once for correct dispatching

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,8 +231,14 @@ async function dispatch(submission) {
                                                  && r.matchSentByEenheidClass(submissionInfo.creatorType)
                                                 );
 
-    for(const rule of applicableRules) {
-      const destinators = await getDestinators(submissionInfo, rule);
+    let destinators;
+    for (const rule of applicableRules) {
+      const currDestinators = await getDestinators(submissionInfo, rule);
+      destinators = destinators.concat(currDestinators);
+    }
+
+    //for(const rule of applicableRules) {
+      //const destinators = await getDestinators(submissionInfo, rule);
       let relatedSubjects = [ submissionInfo.submission ];
 
       for (const config of exportConfig) {
@@ -315,6 +321,6 @@ async function dispatch(submission) {
 
       for (const { subject, graph, toRemoveFirst } of missingSubjectsPerGraph)
         await copySubjectDataToGraph(subject, graph, toRemoveFirst);
-    }
+    //}
   }
 }

--- a/app.js
+++ b/app.js
@@ -231,7 +231,7 @@ async function dispatch(submission) {
                                                  && r.matchSentByEenheidClass(submissionInfo.creatorType)
                                                 );
 
-    let destinators;
+    let destinators = [];
     for (const rule of applicableRules) {
       const currDestinators = await getDestinators(submissionInfo, rule);
       destinators = destinators.concat(currDestinators);


### PR DESCRIPTION
Use all rules combined to get destinators before copying subjects.

[In a previous PR](https://github.com/lblod/worship-submissions-graph-dispatcher-service/pull/25), the improved healing introduced more selective updates and deletes. The dispatching rules where still processed one by one. If multiple rules match for the given subject, one rule would correctly copy the data to their organisation, but the next rule would erase all the dispatched data again because that rule was for a different case for which no destinators could be found for this subject at this time.

In other words: more than one dispatching rule can be applied for a given subject. Some rules are for different use cases and not all of them supply (all) destinators. Rules that are executed later completely override what a previous rule had stated. Data is always copied and deleted in order to be fully representative of the current rule. The effect was that the submissions are only dispatched according to the latest configured rule.