### PR TITLE
Handle multiple decision and creator types in submissions

### DIFF
--- a/app.js
+++ b/app.js
@@ -226,10 +226,17 @@ async function dispatch(submission) {
   const submissionInfo = await getSubmissionInfo(submission);
 
   if(submissionInfo) {
-    const applicableRules = dispatchRules.filter(r =>
-                                                 r.documentType == submissionInfo.submissionType
-                                                 && r.matchSentByEenheidClass(submissionInfo.creatorType)
-                                                );
+    const applicableRules = dispatchRules.filter(r => {
+      const isOneSubmissionTypeIncluded = submissionInfo.submissionTypes.includes(r.documentType);
+      let isOneCreatorTypeIncluded = false;
+      for (const creatorType of submissionInfo.creatorTypes) {
+        if (r.matchSentByEenheidClass(creatorType)) {
+          isOneCreatorTypeIncluded = true;
+        }
+      }
+
+      return isOneSubmissionTypeIncluded && isOneCreatorTypeIncluded;
+    });
 
     let destinators = [];
     for (const rule of applicableRules) {

--- a/util/queries.js
+++ b/util/queries.js
@@ -68,8 +68,17 @@ export async function getSubmissionInfo(submission) {
             <http://mu.semte.ch/vocabularies/ext/decisionType> ?submissionType.
     }
   `;
-  //TODO it is assumed to return MAX 1 result
-  return parseResult(await query(queryStr))[0];
+
+  const parsedResult = parseResult(await query(queryStr));
+
+  // We can receive a submission with multiple decision types and creator types that all need to be evaluated
+  return {
+    submission: parsedResult[0].submission,
+    creator: parsedResult[0].creator,
+    creatorUuid: parsedResult[0].creatorUuid,
+    submissionTypes: parsedResult.map(res => res.submissionType),
+    creatorTypes: parsedResult.map(res => res.creatorType)
+  };
 }
 
 export async function getDestinators(submissionInfo, rule) {


### PR DESCRIPTION
# Issue

Some submissions submitted by vendors have multiple decision and creator, and in that list of types sometimes one is defined in the rules and the other not. When it arrives in the dispatching, only the first-found type is evaluated and if, bad luck that one is not in the rules, the submission isn't dispatched.

# Solution

Make the service more resilient to check all the decision and creator types in the rules for a match in the rules.

# Relates to
- [DL-6182]
- [DL-6174]