### PR TITLE
Include 'betrokken besturen' in 2 Submission types

### DIFF
--- a/dispatch-rules/besluit-budgetwijziging.js
+++ b/dispatch-rules/besluit-budgetwijziging.js
@@ -1,8 +1,9 @@
 import { sparqlEscapeUri } from "mu";
+import { toezichtAndFinancierendBetrokkenheid } from "./query-snippets";
 
 const rules = [];
 
-/* Excel: Rules number: 92, 93, 94, 95, 96, 97, 98, 99
+/* Excel: Rules number: 92, 93, 94, 95, 96, 97, 98, 99, 171, 172
  * Testing:
  *--------------------------
  * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/14278813524c762255aeba149e7d7134ddecfbb43e7d56910731bd4e13e34f39> Prov. limburg
@@ -81,6 +82,8 @@ let rule = {
             mu:uuid ?uuid ;
             skos:prefLabel ?label;
             a <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>.
+       } UNION {
+          ${toezichtAndFinancierendBetrokkenheid()}
        }
       }
     `;

--- a/dispatch-rules/besluit-meerjarenplanwijziging.js
+++ b/dispatch-rules/besluit-meerjarenplanwijziging.js
@@ -1,8 +1,9 @@
 import { sparqlEscapeUri } from "mu";
+import { toezichtAndFinancierendBetrokkenheid } from "./query-snippets";
 
 const rules = [];
 
-/* Excel: Rules number: 111, 112, 113, 114, 115, 116, 117, 118
+/* Excel: Rules number: 111, 112, 113, 114, 115, 116, 117, 118, 173, 174
  * Testing:
  *--------------------------
  * -SENDER-: <http://data.lblod.info/id/bestuurseenheden/14278813524c762255aeba149e7d7134ddecfbb43e7d56910731bd4e13e34f39> Prov. limburg
@@ -81,6 +82,8 @@ let rule = {
             mu:uuid ?uuid ;
             skos:prefLabel ?label;
             a <http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan>.
+       } UNION {
+          ${toezichtAndFinancierendBetrokkenheid()}
        }
       }
     `;

--- a/dispatch-rules/query-snippets.js
+++ b/dispatch-rules/query-snippets.js
@@ -17,6 +17,25 @@ export const allTypeLocaleBetrokkenheid = () => `
           <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
 `;
 
+export const toezichtAndFinancierendBetrokkenheid = () => `
+          VALUES ?classificatie {
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+          }
+          VALUES ?typeLocaleBetrokkenheid {
+            <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e>
+            <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
+          }
+          ?betrokkenBestuur
+            <http://www.w3.org/ns/org#organization> ?sender ;
+            <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeLocaleBetrokkenheid .
+          ?bestuurseenheid
+            <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur ;
+            <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie ;
+            mu:uuid ?uuid ;
+            <http://www.w3.org/2004/02/skos/core#prefLabel> ?label .
+`;
+
 export const toezichthoudendeQuerySnippet = () => `
           VALUES ?classificatie {
               <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>

--- a/dispatch-rules/query-snippets.js
+++ b/dispatch-rules/query-snippets.js
@@ -27,7 +27,7 @@ export const toezichtAndFinancierendBetrokkenheid = () => `
             <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>
           }
           ?betrokkenBestuur
-            <http://www.w3.org/ns/org#organization> ?sender ;
+            <http://www.w3.org/ns/org#organization> ?aboutEenheid ;
             <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> ?typeLocaleBetrokkenheid .
           ?bestuurseenheid
             <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur ;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worship-submissions-graph-dispatcher-service",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Microservice moves meb:Submissions to correct org graph.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**[DL-6234]**

Include the 'betrokken besturen' ('mede-financierend' and 'toezichthoudend') as recievers of submission types

* Besluit over budget(wijziging) eredienstbestuur
* Besluit over meerjarenplan(aanpassing) eredienstbestuur

For this we use the `about_eenheid` instead of the creator of the submissions.