### PR TITLE
Feature/abb sub group destinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ DISPATCH_SOURCE_GRAPH : The source graph of the submissions defaults to 'http://
 HEALING_CRON : cron pattern for healing defaults to '00 07 * * 06'; //Weekly on saturday
 ENABLE_HEALING : enables healing, defaults to false
 NUMBER_OF_HEALING_QUEUES: the number of healing queues availible, for parallel processing purposes. Defaults to '1'
+ABB_UUID: the UUID of ABB, defaults to "141d9d6b-54af-4d17-b313-8d1c30bc3f5b"
 ```
 ## API
 ### POST /delta
@@ -69,3 +70,62 @@ This endpoint allows for the manual triggering of the dispatch process. It doesn
 **Usage:**
 - To dispatch a specific submission, provide `?subject=http://submissions/123`
 - Without any query parameters, the endpoint will re-dispatch all submissions present in `DISPATCH_SOURCE_GRAPH`.
+
+## Anatomy of a dispatch-rule
+Calculating the destinators is complex. It can depend on:
+1. Type of document
+2. Type of bestuurseenheid who sends it
+   2.1. And if ABB is a destinator, extra rules apply
+3. Extra information in the submission itself (typically defined in the `eli:is_about` predicate)
+
+The file contains a high-level specification of the rules:
+[Business Rules](https://docs.google.com/spreadsheets/d/1NnZHqaFnNToE-aZMiyDI1QIPhHP5EG8i39KGFhTazlg/edit?usp=sharing)
+This is what the business uses.
+
+A rule contains the information required to dispatch the submission to the correct (sub-)organization (i.e., the correct graph).
+But also a little bit more.
+
+Take for example:
+
+```
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
+  documentType:
+    "https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", // Aanvraag desaffectatie presbyteria/kerken
+  matchSentByEenheidClass: (eenheidClass) =>
+    eenheidClass ==
+    "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001",
+  destinationInfoQuery: (sender) => {
+    return `
+      PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+      PREFIX org: <http://www.w3.org/ns/org#>
+      PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+      SELECT DISTINCT ?bestuurseenheid ?uuid ?label WHERE {
+        BIND(${sparqlEscapeUri(sender)} as ?sender)
+          VALUES ?bestuurseenheid {
+            <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+            ${sparqlEscapeUri(sender)}
+          }
+          ?bestuurseenheid mu:uuid ?uuid;
+            skos:prefLabel ?label.
+      }
+    `;
+  },
+};
+```
+A breakdown of the fields:
+- `[OPTIONAL] abbSubgroupDestination`:
+  If detected that a submission should go to ABB, this field is taken into account.
+  Within ABB, at the moment, there are (essentially) two roles: the default one, and LF.
+  The default one can access all submissions with destinator ABB, LF only a subset.
+  This info is used to generate the correct target graph, only for ABB.
+  Currently, no extra rules exist for other target organizations, so this information is ignored in other cases.
+- `[REQUIRED] documentType`:
+  Specifies what document type the rule applies to. Conceptually speaking, we don't really need this, and we could dump everything in `destinationInfoQuery`. However, this would trigger lots of querying, and we want to avoid this. So this is basically a shorthand.
+- `[REQUIRED] matchSentByEenheidClass`: This is a function that returns a boolean, based on the `BestuurseenheidClassificatieCode`.
+  Dispatching not only depends on documentType, but also on who created the document. This helps to differentiate the rule.
+  Again, conceptually speaking, we don't really need this, and we could dump everything in `destinationInfoQuery`.
+  However, this would trigger lots of querying, and we want to avoid this. So this is basically a shorthand.
+- `[REQUIRED] destinationInfoQuery`: `function (sender, [optional] submission)` returns the full query to calculate the effective destinators.
+  Sometimes, sender info is not sufficient; the submission can also contain (extra) information about whom the submission is intended for.
+  Only destinationInfoQuery will return the correct query to match the bestuurseenheden where the submission should go to.

--- a/app.js
+++ b/app.js
@@ -8,7 +8,7 @@ import {
   getTypesForSubject,
   getSubmissionForSubject,
   getSubmissionInfo,
-  getDestinators,
+  calculateDestinatorGraphs,
   removeSubjectFromGraph,
   copySubjectDataToGraph,
   getRelatedSubjectsForSubmission,
@@ -21,8 +21,6 @@ import { DISPATCH_SOURCE_GRAPH,
          DISPATCH_FILES_GRAPH,
          ENABLE_HEALING,
          HEALING_CRON,
-         ORG_GRAPH_BASE,
-         ORG_GRAPH_SUFFIX,
          NUMBER_OF_HEALING_QUEUES
        } from './config';
 
@@ -240,7 +238,7 @@ async function dispatch(submission) {
 
     let destinators = [];
     for (const rule of applicableRules) {
-      const currDestinators = await getDestinators(submissionInfo, rule);
+      const currDestinators = await calculateDestinatorGraphs(submissionInfo, rule);
       destinators = destinators.concat(currDestinators);
     }
 
@@ -259,10 +257,10 @@ async function dispatch(submission) {
 
     // Scalar product of related subjects and graphs they should be in
     const allSubjectsAndGraphs = relatedSubjects.reduce((acc, curr) => {
-      destinators.forEach((d) => {
+      destinators.forEach((destinatorGraph) => {
         acc.push({
           subject: curr,
-          graph: ORG_GRAPH_BASE + '/' + d.uuid + '/' + ORG_GRAPH_SUFFIX
+          graph: destinatorGraph
         });
       });
       return acc;

--- a/config.js
+++ b/config.js
@@ -5,3 +5,4 @@ export const DISPATCH_FILES_GRAPH = process.env.DISPATCH_FILES_GRAPH || 'http://
 export const HEALING_CRON = process.env.HEALING_CRON || '00 07 * * 06'; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
 export const NUMBER_OF_HEALING_QUEUES = parseInt(process.env.NUMBER_OF_HEALING_QUEUES) || 1;
+export const ABB_UUID = process.env.ABB_UUID || "141d9d6b-54af-4d17-b313-8d1c30bc3f5b";

--- a/dispatch-rules/aanvraag-desaffectatie-presbyteria-kerken.js
+++ b/dispatch-rules/aanvraag-desaffectatie-presbyteria-kerken.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -10,6 +11,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
  **/
 let rule = {
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType:
     "https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", // Aanvraag desaffectatie presbyteria/kerken
   matchSentByEenheidClass: (eenheidClass) =>

--- a/dispatch-rules/advies-budgetwijziging.js
+++ b/dispatch-rules/advies-budgetwijziging.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 86, 87
@@ -15,6 +16,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6', // Advies budgetwijziging - EB if EB without CB or CB if EB has CB
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/advies-budgetwijziging.js
+++ b/dispatch-rules/advies-budgetwijziging.js
@@ -16,7 +16,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6', // Advies budgetwijziging - EB if EB without CB or CB if EB has CB
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/advies-jaarrekening.js
+++ b/dispatch-rules/advies-jaarrekening.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -9,6 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c', // Advies jaarrekening
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/advies-jaarrekening.js
+++ b/dispatch-rules/advies-jaarrekening.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c', // Advies jaarrekening
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/advies-meerjarenplanwijziging.js
+++ b/dispatch-rules/advies-meerjarenplanwijziging.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 109, 110

--- a/dispatch-rules/afschrift-erkenningszoekende-besturen.js
+++ b/dispatch-rules/afschrift-erkenningszoekende-besturen.js
@@ -15,7 +15,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2', // Afschrift erkenningszoekende besturen
   matchSentByEenheidClass: (eenheidClass) =>
     eenheidClass ==

--- a/dispatch-rules/afschrift-erkenningszoekende-besturen.js
+++ b/dispatch-rules/afschrift-erkenningszoekende-besturen.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { allTypeLocaleBetrokkenheid, repOrgQuerySnippet } from './query-snippets';
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -14,6 +15,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/6375F8724B5FEAF28DEDE821> Attaqwa
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2', // Afschrift erkenningszoekende besturen
   matchSentByEenheidClass: (eenheidClass) =>
     eenheidClass ==

--- a/dispatch-rules/besluit-budgetwijziging.js
+++ b/dispatch-rules/besluit-budgetwijziging.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichtAndFinancierendBetrokkenheid } from "./query-snippets";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -22,6 +23,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> Kerkfabriek St.-Apollonia van Roosdaal (Pamel)
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46', // Besluit budgetwijziging
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/besluit-budgetwijziging.js
+++ b/dispatch-rules/besluit-budgetwijziging.js
@@ -23,7 +23,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> Kerkfabriek St.-Apollonia van Roosdaal (Pamel)
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46', // Besluit budgetwijziging
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/besluit-handhaven.js
+++ b/dispatch-rules/besluit-handhaven.js
@@ -21,7 +21,7 @@ const rules = [];
  * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946',
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/besluit-handhaven.js
+++ b/dispatch-rules/besluit-handhaven.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichthoudendeQuerySnippet, repOrgQuerySnippet } from './query-snippets';
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -20,6 +21,7 @@ const rules = [];
  * CB: <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> CKB Aalst
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946',
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/besluit-meerjarenplanwijziging.js
+++ b/dispatch-rules/besluit-meerjarenplanwijziging.js
@@ -23,7 +23,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> Kerkfabriek St.-Apollonia van Roosdaal (Pamel)
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b', // Besluit meerjarenplanwijziging
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/besluit-meerjarenplanwijziging.js
+++ b/dispatch-rules/besluit-meerjarenplanwijziging.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichtAndFinancierendBetrokkenheid } from "./query-snippets";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -22,6 +23,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> Kerkfabriek St.-Apollonia van Roosdaal (Pamel)
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b', // Besluit meerjarenplanwijziging
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichthoudendeQuerySnippet } from "./query-snippets";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -62,6 +63,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b', // Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan - EB zonder CB
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB zonder CB
   destinationInfoQuery: ( sender ) => {
@@ -115,6 +117,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d85218e2-a75f-4a30-9182-512b5c9dd1b2', // Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie - EB zonder CB
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB zonder CB
   destinationInfoQuery: ( sender ) => {
@@ -152,6 +155,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29', // Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {
@@ -186,6 +190,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349', // Budgetten(wijzigingen) - betreffende besturen van de eredienst - Indiening bij Representatief orgaan - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {
@@ -232,6 +237,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget EB without CB
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -63,7 +63,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b', // Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan - EB zonder CB
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB zonder CB
   destinationInfoQuery: ( sender ) => {
@@ -117,7 +117,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d85218e2-a75f-4a30-9182-512b5c9dd1b2', // Budget(wijziging)- Indiening bij toezichthoudende gemeente of provincie - EB zonder CB
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB zonder CB
   destinationInfoQuery: ( sender ) => {
@@ -155,7 +155,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29', // Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {
@@ -190,7 +190,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349', // Budgetten(wijzigingen) - betreffende besturen van de eredienst - Indiening bij Representatief orgaan - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {
@@ -237,7 +237,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 */
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/40831a2c-771d-4b41-9720-0399998f1873', // Budget EB without CB
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // Bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/eindrekening.js
+++ b/dispatch-rules/eindrekening.js
@@ -10,7 +10,7 @@ const rules = [];
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347', // Eindrekening (ER)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/eindrekening.js
+++ b/dispatch-rules/eindrekening.js
@@ -1,4 +1,6 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
+
 const rules = [];
 
 /* Excel: Rules number: 77
@@ -8,6 +10,7 @@ const rules = [];
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347', // Eindrekening (ER)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', // EB
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/entrypoint.js
+++ b/dispatch-rules/entrypoint.js
@@ -26,18 +26,8 @@ import meldingInterneBeslissingTotSamenvoeging from './melding-interne-beslissin
 /*
  * This file exports a list of rule objects, which helps deduce who the targets are for a
  * a specific submission.
- * It tries to translate this file: https://docs.google.com/spreadsheets/d/1NnZHqaFnNToE-aZMiyDI1QIPhHP5EG8i39KGFhTazlg/edit?usp=sharing
- * Rule object has the following shape:
- *  {
- *    documentType: 'http://uri/of/type/doc',
- *    matchSentByEenheidClass: eenheidClass => { returns true if bestuurseenheidClassificatieCode matches }
- *    destinationInfoQuery: ( sender, submission = null ) => {
- *      returns string of query to execute to find matching eenheiden where to dispatch to
- *    }
- *  }
- *
- * The property of documentType and matchSentByEenheidClass are used to pre-filter the rules. This to avoid extra load on the database.
- * Only destinationInfoQuery will return the correct query to match the bestuurseenheden where the submission should go to.
+ * Check the README.md#Anatomy of a dispatch-rule.
+ * Please, if things change in the format of the rules, please update the doc there.
  */
 
 const rules = [

--- a/dispatch-rules/erekenning-reguliere-procedure.js
+++ b/dispatch-rules/erekenning-reguliere-procedure.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX ],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73', // Erkenning - reguliere procedure
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/erekenning-reguliere-procedure.js
+++ b/dispatch-rules/erekenning-reguliere-procedure.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 142
@@ -9,6 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73', // Erkenning - reguliere procedure
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/erekenning-reguliere-procedure.js
+++ b/dispatch-rules/erekenning-reguliere-procedure.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73', // Erkenning - reguliere procedure
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/jaarrekening.js
+++ b/dispatch-rules/jaarrekening.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichthoudendeQuerySnippet } from './query-snippets';
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -53,6 +54,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB zonder CB 
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB
   destinationInfoQuery: ( sender ) => {
@@ -115,6 +117,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461', // Jaarrekening (JR + Toelagenoverzicht)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // CB
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/jaarrekening.js
+++ b/dispatch-rules/jaarrekening.js
@@ -54,7 +54,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB zonder CB 
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB
   destinationInfoQuery: ( sender ) => {
@@ -117,7 +117,7 @@ rules.push(rule);
 * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461', // Jaarrekening (JR + Toelagenoverzicht)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // CB
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/meerjarenplanwijziging.js
+++ b/dispatch-rules/meerjarenplanwijziging.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichthoudendeQuerySnippet } from './query-snippets';
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -66,6 +67,7 @@ rules.push(rule);
 * GO: <http://data.lblod.info/id/bestuurseenheden/2ad0d123f4a81787572342c394a1917b81752f42d802d1e013941f56b53bdd2a> Gemeente Haacht
 **/
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f', // Meerjarenplan(wijziging)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB zonder CB
   destinationInfoQuery: ( sender ) => {
@@ -127,6 +129,7 @@ rules.push(rule);
 * RO: <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> Bisdom Hasselt
 */
 rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e', // Meerjarenplan(wijziging) - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/meerjarenplanwijziging.js
+++ b/dispatch-rules/meerjarenplanwijziging.js
@@ -67,7 +67,7 @@ rules.push(rule);
 * GO: <http://data.lblod.info/id/bestuurseenheden/2ad0d123f4a81787572342c394a1917b81752f42d802d1e013941f56b53bdd2a> Gemeente Haacht
 **/
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f', // Meerjarenplan(wijziging)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB zonder CB
   destinationInfoQuery: ( sender ) => {
@@ -129,7 +129,7 @@ rules.push(rule);
 * RO: <http://data.lblod.info/id/representatieveOrganen/c98e270d84a8455b2f4bf16b915aeff2> Bisdom Hasselt
 */
 rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e', // Meerjarenplan(wijziging) - CB namens EB's
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054', // Centraal bestuur van de eredienst
   destinationInfoQuery: ( sender ) => {

--- a/dispatch-rules/melding-interne-beslissing-tot-samenvoeging.js
+++ b/dispatch-rules/melding-interne-beslissing-tot-samenvoeging.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: TODO: update excel?

--- a/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
+++ b/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
@@ -33,7 +33,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
  **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType:
     "https://data.vlaanderen.be/id/concept/BesluitDocumentType/863caf68-97c9-4ee0-adb5-620577ea8146", // Melding onvolledigheid inzending eredienstbestuur
     matchSentByEenheidClass: eenheidClass => {

--- a/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
+++ b/dispatch-rules/melding-onvolledigheid-inzending-eredienstbestuur.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -32,6 +33,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
  **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType:
     "https://data.vlaanderen.be/id/concept/BesluitDocumentType/863caf68-97c9-4ee0-adb5-620577ea8146", // Melding onvolledigheid inzending eredienstbestuur
     matchSentByEenheidClass: eenheidClass => {

--- a/dispatch-rules/naamswijziging.js
+++ b/dispatch-rules/naamswijziging.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777', // Naamswijziging
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/naamswijziging.js
+++ b/dispatch-rules/naamswijziging.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 144
@@ -9,6 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777', // Naamswijziging
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/notulen.js
+++ b/dispatch-rules/notulen.js
@@ -24,7 +24,7 @@ const rules = [];
  * RO: <http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1> Oecumenisch Patriarchaat van Konstantinopel
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773', // Notulen EB
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/notulen.js
+++ b/dispatch-rules/notulen.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichthoudendeQuerySnippet, repOrgQuerySnippet } from './query-snippets';
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -23,6 +24,7 @@ const rules = [];
  * RO: <http://data.lblod.info/id/representatieveOrganen/0ebb44c2ef14d86978ea85e74d128ad1> Oecumenisch Patriarchaat van Konstantinopel
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/8e791b27-7600-4577-b24e-c7c29e0eb773', // Notulen EB
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
+++ b/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e', // Opheffing van annexe kerken en kapelanijen
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
+++ b/dispatch-rules/opheffing-van-annexe-kerken-en-kapelanijen.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 140
@@ -9,6 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e', // Opheffing van annexe kerken en kapelanijen
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing.js
+++ b/dispatch-rules/opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing.js
@@ -35,7 +35,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
  **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType:
     "https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae", // Opstart beroepsprocedure naar aanleiding van een beslissing
     matchSentByEenheidClass: eenheidClass => {

--- a/dispatch-rules/opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing.js
+++ b/dispatch-rules/opstart-beroepsprocedure-naar-aanleiding-van-een-beslissing.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -34,6 +35,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
  **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType:
     "https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae", // Opstart beroepsprocedure naar aanleiding van een beslissing
     matchSentByEenheidClass: eenheidClass => {

--- a/dispatch-rules/opvragen-bijkomende-inlichtingen-eredienstbesturen.js
+++ b/dispatch-rules/opvragen-bijkomende-inlichtingen-eredienstbesturen.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 

--- a/dispatch-rules/reactie-op-opvragen-bijkomende-inlichtingen-door-de-toezichthouder-aan-de-eredienstbesturen.js
+++ b/dispatch-rules/reactie-op-opvragen-bijkomende-inlichtingen-door-de-toezichthouder-aan-de-eredienstbesturen.js
@@ -1,5 +1,6 @@
 import { sparqlEscapeUri } from "mu";
 import { toezichthoudendeQuerySnippet } from './query-snippets';
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 

--- a/dispatch-rules/samenvoeging.js
+++ b/dispatch-rules/samenvoeging.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 141
@@ -9,6 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a', // Samenvoeging
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/samenvoeging.js
+++ b/dispatch-rules/samenvoeging.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a', // Samenvoeging
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/samenvoeging.js
+++ b/dispatch-rules/samenvoeging.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX ],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a', // Samenvoeging
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/schorsingsbesluit.js
+++ b/dispatch-rules/schorsingsbesluit.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 
@@ -21,6 +22,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> Kerkfabriek St.-Apollonia van Roosdaal (Pamel)
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827', // schorsingsbesluit
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/schorsingsbesluit.js
+++ b/dispatch-rules/schorsingsbesluit.js
@@ -22,7 +22,7 @@ const rules = [];
  * EB: <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> Kerkfabriek St.-Apollonia van Roosdaal (Pamel)
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827', // schorsingsbesluit
   matchSentByEenheidClass: eenheidClass => {
     return [

--- a/dispatch-rules/wijziging-gebiedsomschrijving.js
+++ b/dispatch-rules/wijziging-gebiedsomschrijving.js
@@ -1,4 +1,5 @@
 import { sparqlEscapeUri } from "mu";
+import { ORG_GRAPH_SUFFIX } from '../config';
 
 const rules = [];
 /* Excel: Rules number: 143
@@ -9,6 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
+  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b', // Wijziging gebiedsomschrijving
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/dispatch-rules/wijziging-gebiedsomschrijving.js
+++ b/dispatch-rules/wijziging-gebiedsomschrijving.js
@@ -10,7 +10,7 @@ const rules = [];
  * PG: <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> ABB
 **/
 let rule = {
-  abbSubgroupDestination: [ "LoketLB-databankEredienstenGebruiker", "LoketLB-databankEredienstenGebruiker-LF"],
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b', // Wijziging gebiedsomschrijving
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213', // RO

--- a/util/queries.js
+++ b/util/queries.js
@@ -90,7 +90,7 @@ export async function calculateDestinatorGraphs(submissionInfo, rule) {
   for(const destination of destinationData) {
     if(destination.uuid == ABB_UUID) {
 
-      if(!destination.abbSubgroupDestination) {
+      if(!rule.abbSubgroupDestination) {
         console.warn(
           `!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             Detected ${submissionInfo.submission} should go to ABB.
@@ -103,7 +103,7 @@ export async function calculateDestinatorGraphs(submissionInfo, rule) {
         destinationGraphs.push(ORG_GRAPH_BASE + '/' + destination.uuid + '/' + ORG_GRAPH_SUFFIX);
       }
       else {
-        for(const ABBSubgroupSuffix of destination.abbSubgroupDestination) {
+        for(const ABBSubgroupSuffix of rule.abbSubgroupDestination) {
           destinationGraphs.push(ORG_GRAPH_BASE + '/' + destination.uuid + '/' + ABBSubgroupSuffix);
         }
       }


### PR DESCRIPTION
:warning: Don't merge, as long as ACM is not ready.

Extra complications in the rules need to be taken into account.
ABB was previously considered as a destination in its entirety.
Now, the business has requested to make a distinction within ABB.
There is a default ABB group, which can still see all submissions meant for ABB, and there is LF, which should only see a subset of these submissions.

This extra logic has been implemented as follows:

- Rules have been extended with the field `abbSubgroupDestination` .
   - Creates a lot of file changes, but I wanted a whitelist type of approach. We avoid accidents by doing so.
   - I would leave the full testing to the testers and would skip going over them. It's boring.
- A minor refactor to calculate the destination graph with this new parameter.
- The current rules are simple: LF can see all but two types of submissions. The exact commit of this specification can be found [here](https://github.com/lblod/worship-submissions-graph-dispatcher-service/commit/6a3cb503077f54c41c26da53c2eab8312d5e352e).
- Documentation in the README.md has been updated with the "Anatomy of a dispatch rule."
- An extra column has been added in the [Business Rules](https://docs.google.com/spreadsheets/d/1NnZHqaFnNToE-aZMiyDI1QIPhHP5EG8i39KGFhTazlg/edit?usp=sharing) to help keep track on a less technical level.
- See also: DL-6512

Testing this -> I woud refer to https://github.com/lblod/app-worship-decisions-database/pull/101, which requires less fiddling
 