### PR TITLE
Adjust `getSubmissionInfo` to return null when no result found

### DIFF
--- a/app.js
+++ b/app.js
@@ -223,7 +223,7 @@ async function processSubject(subject) {
 async function dispatch(submission) {
   const submissionInfo = await getSubmissionInfo(submission);
 
-  if(submissionInfo) {
+  if (submissionInfo) {
     const applicableRules = dispatchRules.filter(r => {
       const isOneSubmissionTypeIncluded = submissionInfo.submissionTypes.includes(r.documentType);
       let isOneCreatorTypeIncluded = false;

--- a/util/queries.js
+++ b/util/queries.js
@@ -71,14 +71,17 @@ export async function getSubmissionInfo(submission) {
 
   const parsedResult = parseResult(await query(queryStr));
 
-  // We can receive a submission with multiple decision types and creator types that all need to be evaluated
-  return {
-    submission: parsedResult[0].submission,
-    creator: parsedResult[0].creator,
-    creatorUuid: parsedResult[0].creatorUuid,
-    submissionTypes: parsedResult.map(res => res.submissionType),
-    creatorTypes: parsedResult.map(res => res.creatorType)
-  };
+  if (parsedResult.length) {
+    // We can receive a submission with multiple decision types and creator types that all need to be evaluated
+    return {
+      submission: parsedResult[0].submission,
+      creator: parsedResult[0].creator,
+      creatorUuid: parsedResult[0].creatorUuid,
+      submissionTypes: parsedResult.map(res => res.submissionType),
+      creatorTypes: parsedResult.map(res => res.creatorType)
+    };
+  }
+  return null;
 }
 
 export async function calculateDestinatorGraphs(submissionInfo, rule) {


### PR DESCRIPTION
# Context

[DL-6989]

Submissions are often received in multiple batches via the submissions consumer. The consequence is that sometimes, only part of the data is in the triplestore until the next consumption round. When this service then tries to dispatch, it is possible that it doesn't find the submissions info right away. We should handle this case, otherwise an exception is thrown and it causes the business to receive alert emails about the dispatching even though there is no real issue.

# How to test

You can reproduce the issue by wiring your local stack of `app-worship-decisions-database` to Dev Loket as such:
```
  submissions-consumer:
    environment:
      DCR_SYNC_BASE_URL: 'https://dev.loket.lblod.info/'
      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/worship-submissions/login'
      DCR_SECRET_KEY: "check-dev-config-to-fill-the-secret"
```
Then create a submission in Loket, let your local `app-worship-decisions-database` do the first round on consumption, the dispatcher will likely throw `Error while processing a subject http://data.lblod.info/submission-documents/xxx: Cannot read property 'submission' of undefined`.

With this PR, it doesn't error out, it just doesn't dispatch anything until more data is received.