### PR TITLE
DL-7352: mini healing to heal submissions created in the last 24 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ By correct: we mean as defined by business rules. See code for exact implementat
   1. on incoming delta, if a `meb:Submission` can be deduced, it will fetch it and dispatch to the correct org graph.
   2. Periodic healing, if enabled, will remove all submissions from their current target graph, and re-dispatch them again.
     - This tackles the case of changes in relations between bestuurseenheden, which affects which organisation a submission should belong to.
+    - A daily mini-healing will also be enabled to have the same healing effect but for submissions created in the last 24 hours.
 
 ## Installation
 Add the following snippet to your `docker-compose.yml`:
@@ -47,6 +48,7 @@ ORG_GRAPH_BASE : The base uri of the org graph; defaults to 'http://mu.semte.ch/
 ORG_GRAPH_SUFFIX : The postfix of the org-graph  defaults to 'ABB_databankErediensten_LB_CompEnts_gebruiker';
 DISPATCH_SOURCE_GRAPH : The source graph of the submissions defaults to 'http://mu.semte.ch/graphs/temp/for-dispatch';
 HEALING_CRON : cron pattern for healing defaults to '00 07 * * 06'; //Weekly on saturday
+MINI_HEALING_CRON : cron pattern for healing defaults to '0 2 * * *'; //Daily at 2 AM
 ENABLE_HEALING : enables healing, defaults to false
 NUMBER_OF_HEALING_QUEUES: the number of healing queues availible, for parallel processing purposes. Defaults to '1'
 ABB_UUID: the UUID of ABB, defaults to "141d9d6b-54af-4d17-b313-8d1c30bc3f5b"

--- a/app.js
+++ b/app.js
@@ -23,6 +23,7 @@ import {
   DISPATCH_FILES_GRAPH,
   ENABLE_HEALING,
   HEALING_CRON,
+  MINI_HEALING_CRON,
   NUMBER_OF_HEALING_QUEUES,
 } from "./config";
 import { addMany } from "./util/set";
@@ -56,6 +57,33 @@ if (ENABLE_HEALING) {
     },
     null,
     true,
+  );
+
+  console.log(`MINI_HEALING_CRON is set to ${MINI_HEALING_CRON}`);
+  new CronJob(
+      MINI_HEALING_CRON,
+      async function () {
+        const now = new Date();
+        console.info(`Mini healing sync triggered by cron job at ${now.toISOString()}`);
+
+        const yesterday = new Date(now);
+        yesterday.setDate(yesterday.getDate() - 1);
+        const sentDateSince = yesterday.toISOString().split("T")[0];
+
+        console.info(`Mini healing will process submissions from ${sentDateSince} onwards`);
+
+        const submissions = await getSubmissions({ sentDateSince });
+        console.info(`Found ${submissions.length} submissions to heal from the last 24 hours`);
+
+        for (const submission of submissions) {
+          distributeAndSchedule(
+              healingQueuePool,
+              async () => await processSubject(submission),
+          );
+        }
+      },
+      null,
+      true,
   );
 }
 

--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ export const DISPATCH_FILES_GRAPH =
   "http://mu.semte.ch/graphs/temp/original-physical-files-data";
 export const HEALING_CRON = process.env.HEALING_CRON || "00 07 * * 06"; //Weekly on saturday
 export const ENABLE_HEALING = process.env.ENABLE_HEALING == "true";
+export const MINI_HEALING_CRON = process.env.MINI_HEALING_CRON || "0 2 * * *"; //Daily at 2 AM
 export const NUMBER_OF_HEALING_QUEUES =
   parseInt(process.env.NUMBER_OF_HEALING_QUEUES) || 1;
 export const ABB_UUID =


### PR DESCRIPTION
- Added daily mini healing cron that does the same as the main healing cron but for submissions created in the last 24 hours.

TO TEST:
- rsync
- create local image
- docker-compose.override:
                    `  submissions-dispatcher:
                        image: local/worship-submissions-graph-dispatcher-service
                        environment:
                          ORG_GRAPH_SUFFIX: "LoketLB-databankEredienstenGebruiker"
                          SUDO_QUERY_RETRY: "true"
                          SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES: "404,500"
                          ALLOW_MU_AUTH_SUDO: "true"
                          MINI_HEALING_CRON: "*/3 * * * *"
                          ENABLE_HEALING: "true"
                        labels:
                          - "logging=true"
                        restart: always
                        logging: *default-logging`
- drc up -d
- check that mini healing picks up submissions created in the last 24 hours and moves them to the correct graphs.

(You can delete submission data from all its organisation graphs + set date to current time and check if everything gets readded via the mini cron)
