### PR TITLE
Submissions for abb users

### DIFF
--- a/dispatch-rules/budgetwijziging.js
+++ b/dispatch-rules/budgetwijziging.js
@@ -12,6 +12,7 @@ const rules = [];
 * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Gemeente Deinze (only receives submission, when CKB has made a parent submission)
 **/
 let rule = {
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/d463b6d1-c207-4c1a-8c08-f2c7dd1fa53b', // Budget(wijziging) - Indiening bij Centraal bestuur of Representatief orgaan - EB met CB 
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB (Active)
   destinationInfoQuery: ( sender, submission ) => {

--- a/dispatch-rules/jaarrekening.js
+++ b/dispatch-rules/jaarrekening.js
@@ -12,6 +12,7 @@ const rules = [];
 * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Gemeente Deinze (only receives submission, when CKB has made a parent submission)
 **/
 let rule = {
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c', //Jaarrekening (JR) - EB met CB (Active)
   matchSentByEenheidClass: eenheidClass => eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB
   destinationInfoQuery: ( sender, submission ) => {

--- a/dispatch-rules/meerjarenplanwijziging.js
+++ b/dispatch-rules/meerjarenplanwijziging.js
@@ -12,6 +12,7 @@ const rules = [];
 * GEMEENTE: <http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8> Gemeente Deinze (only receives submission, when CKB has made a parent submission)
 **/
 let rule = {
+  abbSubgroupDestination: [ ORG_GRAPH_SUFFIX, `${ORG_GRAPH_SUFFIX}-LF`],
   documentType: 'https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f', // Meerjarenplan(wijziging)
   matchSentByEenheidClass: eenheidClass =>
     eenheidClass == 'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86', //EB met CB (Active)

--- a/dispatch-rules/query-snippets.js
+++ b/dispatch-rules/query-snippets.js
@@ -61,33 +61,47 @@ export const repOrgQuerySnippet = () => `
 `;
 
 export const toezichthoudendeAccessingChildSubmissionQuerySnippet = (sender, submission) => /* sparql */`
-  ?ckb 
-    <http://www.w3.org/ns/org#hasSubOrganization> ${sparqlEscapeUri(sender)};
-    <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
-    <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
-    
-  ?betrokkenBestuur 
-    <http://www.w3.org/ns/org#organization> ?ckb;
-    <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
-    a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>.
+  {
+    ?ckb 
+      <http://www.w3.org/ns/org#hasSubOrganization> ${sparqlEscapeUri(sender)};
+      <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>;
+      <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
+      
+    ?betrokkenBestuur 
+      <http://www.w3.org/ns/org#organization> ?ckb;
+      <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+      a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>.
 
-  VALUES ?classificatie {
-    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
-    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+      VALUES ?classificatie {
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+      }
+      ?bestuurseenheid 
+        <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur;
+        <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
+        <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
+        <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+
+      ?parentSubmission
+        a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+        <http://purl.org/pav/createdBy> ?ckb;
+        <http://www.w3.org/ns/prov#generated> ?parentSubmissionFormData.
+        
+      ?parentSubmissionFormData <http://purl.org/dc/terms/relation> ?decision.
+      ${sparqlEscapeUri(submission)}
+        a <http://rdf.myexperiment.org/ontologies/base/Submission>;
+        <http://purl.org/dc/terms/subject> ?decision.
   }
-  ?bestuurseenheid 
-    <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> ?betrokkenBestuur;
-    <http://data.vlaanderen.be/ns/besluit#classificatie> ?classificatie;
-    <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
-    <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
+  UNION
+  {
+    ?bestuurseenheid 
+      <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/52cc9d8d-1c9a-4d92-9936-da9d4a622ec4>;
+      <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
+      <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
     
-  ?parentSubmission
-    a <http://rdf.myexperiment.org/ontologies/base/Submission>;
-    <http://purl.org/pav/createdBy> ?ckb;
-    <http://www.w3.org/ns/prov#generated> ?parentSubmissionFormData.
-    
-  ?parentSubmissionFormData <http://purl.org/dc/terms/relation> ?decision.
-  ${sparqlEscapeUri(submission)}
-    a <http://rdf.myexperiment.org/ontologies/base/Submission>;
-    <http://purl.org/dc/terms/subject> ?decision.
+    BIND(
+      <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
+      AS ?bestuurseenheid
+    )
+  }
 `;

--- a/dispatch-rules/query-snippets.js
+++ b/dispatch-rules/query-snippets.js
@@ -94,14 +94,14 @@ export const toezichthoudendeAccessingChildSubmissionQuerySnippet = (sender, sub
   }
   UNION
   {
-    ?bestuurseenheid 
-      <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/52cc9d8d-1c9a-4d92-9936-da9d4a622ec4>;
-      <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
-      <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
-    
     BIND(
       <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>
       AS ?bestuurseenheid
     )
+      
+    ?bestuurseenheid 
+      <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/52cc9d8d-1c9a-4d92-9936-da9d4a622ec4>;
+      <http://mu.semte.ch/vocabularies/core/uuid> ?uuid;
+      <http://www.w3.org/2004/02/skos/core#prefLabel> ?label.
   }
 `;


### PR DESCRIPTION
[DL-7417]: Extend submissions dispatcher to include orignal documents from bundled documents

This PR makes the original document in worship submissions available. 

How to test:
- Add the service to the stack
- Log into loket as a CKB
- Create a submission with a linked worship service document
- Log into worship decisions database as ABB
- Check if the document is available there